### PR TITLE
docs: honest benchmark numbers — iceoryx2 wins at 64KB+

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -15,23 +15,25 @@ Same-process publisher + subscriber. `try_recv` only (no futex syscall — `WAIT
 
 Proves O(1): latency is flat regardless of how large the backing block is.
 
-| Backing buffer | crossbar | iceoryx2 | speedup |
+| Backing buffer | crossbar | iceoryx2 | ratio |
 |---|---|---|---|
-| 64 B | **56 ns** | 233 ns | 4.2× |
-| 4 KB | **56 ns** | 234 ns | 4.2× |
-| 64 KB | **59 ns** | 237 ns | 4.0× |
-| 256 KB | **59 ns** | 248 ns | 4.2× |
-| 1 MB | **59 ns** | 234 ns | 4.0× |
+| 64 B | **56 ns** | 233 ns | 4.2× faster |
+| 4 KB | **56 ns** | 234 ns | 4.2× faster |
+| 64 KB | **59 ns** | 237 ns | 4.0× faster |
+| 256 KB | **59 ns** | 248 ns | 4.2× faster |
+| 1 MB | **59 ns** | 234 ns | 4.0× faster |
 
 ### End-to-end with full payload (loan → memcpy → publish → recv → deref)
 
-| Payload | crossbar | iceoryx2 | speedup |
+| Payload | crossbar | iceoryx2 | ratio |
 |---|---|---|---|
-| 8 B | **59 ns** | 238 ns | **4.0×** |
-| 1 KB | **74 ns** | 250 ns | 3.4× |
-| 64 KB | 1.66 µs | 1.33 µs | ~1× |
-| 256 KB | 6.97 µs | 6.97 µs | ~1× |
-| 1 MB | 50 µs | 30 µs | ~1× |
+| 8 B | **60 ns** | 235 ns | **3.9× faster** |
+| 1 KB | **72 ns** | 250 ns | **3.5× faster** |
+| 64 KB | 1.53 µs | 1.31 µs | 0.86× (iceoryx2 wins) |
+| 256 KB | 6.84 µs | 7.00 µs | ~1× |
+| 1 MB | 45 µs | 32 µs | 0.71× (iceoryx2 wins) |
+
+At 64 KB+, iceoryx2's `memcpy` path is faster — likely from better SIMD-optimized copy routines or memory prefetching. Crossbar's `set_data()` uses plain `copy_nonoverlapping`. The born-in-SHM pattern (`as_mut_slice()`) eliminates this gap by avoiding the copy entirely.
 
 ### Throughput (born-in-SHM write)
 
@@ -44,7 +46,7 @@ Proves O(1): latency is flat regardless of how large the backing block is.
 
 | | latency |
 |---|---|
-| 8 B, `publish_silent()` | **58 ns** |
+| 8 B, `publish_silent()` | **57 ns** |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ All measurements: Criterion, same-process publisher + subscriber, `try_recv` (no
 
 ### Intel i7-10700KF · Linux 6.8 · rustc 1.87
 
-| | crossbar | iceoryx2 | speedup |
+| | crossbar | iceoryx2 | ratio |
 |---|---|---|---|
-| 8 B (transport overhead) | **56 ns** | 233 ns | **4.2×** |
-| 1 KB | 74 ns | 250 ns | 3.4× |
-| 64 KB | 1.66 µs | 1.33 µs | ~1× |
-| 1 MB | 50 µs | 30 µs | ~1× |
+| 8 B (transport overhead) | **60 ns** | 235 ns | **3.9× faster** |
+| 1 KB | **72 ns** | 250 ns | **3.5× faster** |
+| 64 KB | 1.53 µs | 1.31 µs | 0.86× (iceoryx2 wins) |
+| 1 MB | 45 µs | 32 µs | 0.71× (iceoryx2 wins) |
 
 ### Apple M1 Pro · macOS · rustc 1.92
 
@@ -181,7 +181,7 @@ All measurements: Criterion, same-process publisher + subscriber, `try_recv` (no
 | 64 KB | 1.27 µs | 1.35 µs | 1.1× |
 | 1 MB | 23.9 µs | 23.5 µs | ~1× |
 
-**The win is in the overhead.** At small payloads crossbar's lighter path (no service discovery, no POSIX config layer) is 3–4× faster. At 64 KB+ both frameworks are memcpy-bound and converge. The 8-byte descriptor is always O(1) — payload latency scales with how long you take to write into the block.
+**The win is in the overhead.** At small payloads crossbar's lighter path (no service discovery, no POSIX config layer) is 3–4× faster. At 64 KB+, `memcpy` dominates and iceoryx2's optimized copy path pulls ahead. The 8-byte descriptor is always O(1) — payload latency scales with how long you take to write into the block. For large payloads, use the born-in-SHM pattern (`loan().as_mut_slice()`) to avoid the copy entirely.
 
 Reproduce: `cargo bench -- head_to_head` (requires `iceoryx2` dev-dep, Unix only).
 


### PR DESCRIPTION
## Summary

Previous docs claimed ~1× at large payloads. Back-to-back benchmarking on the same machine in the same thermal state shows:

| Payload | crossbar | iceoryx2 | Honest ratio |
|---------|----------|----------|-------------|
| 8B | **60 ns** | 235 ns | **3.9x faster** |
| 1KB | **72 ns** | 250 ns | **3.5x faster** |
| 64KB | 1.53 µs | 1.31 µs | **0.86x (iceoryx2 wins)** |
| 1MB | 45 µs | 32 µs | **0.71x (iceoryx2 wins)** |

This was true **before** the perf overhaul too — the old 30.9µs number was from a different session with different conditions. The original code in this session benchmarks at 44µs for 1MB.

The gap at 64KB+ is likely iceoryx2's SIMD-optimized memcpy. The born-in-SHM pattern (`as_mut_slice()`) eliminates the copy entirely and closes the gap.

## Test plan
- [x] `cargo test --workspace` — 31/31 pass
- [x] Numbers verified with back-to-back `git stash`/`git stash pop` benchmarking

🤖 Generated with [Claude Code](https://claude.com/claude-code)