### PR TITLE
fix: comprehensive safety hardening from multi-model audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Transfers an 8-byte descriptor through a lock-free ring — O(1) regardless of p
 
 ```toml
 [dependencies]
-crossbar = "0.2"
+crossbar = "0.3"
 ```
 
 ---
@@ -44,8 +44,8 @@ use crossbar::*;
 let mut pub_ = ShmPublisher::create("market", PubSubConfig::default())?;
 let topic = pub_.register("/prices/AAPL")?;
 
-let mut loan = pub_.loan(&topic);
-loan.set_data(b"42.50");
+let mut loan = pub_.loan(&topic).unwrap();
+loan.set_data(b"42.50").unwrap();
 loan.publish(); // O(1) — writes 8 bytes to ring
 ```
 
@@ -78,7 +78,7 @@ unsafe impl Pod for Tick {}
 // Publisher
 let mut pub_ = ShmPublisher::create("market", PubSubConfig::default())?;
 let topic = pub_.register_typed::<Tick>("/prices/AAPL")?;
-let mut loan = pub_.loan_typed::<Tick>(&topic);
+let mut loan = pub_.loan_typed::<Tick>(&topic).unwrap();
 *loan.as_mut() = Tick { price: 42.50, volume: 1000 };
 loan.publish();
 
@@ -149,11 +149,11 @@ let reply = cli.recv()?;
 Write directly into the pool block — no intermediate buffer, no copy at any payload size:
 
 ```rust
-let mut loan = pub_.loan(&topic);
+let mut loan = pub_.loan(&topic).unwrap();
 let buf = loan.as_mut_slice();
 // write directly into shared memory
 encode_frame(&mut buf[..frame_len]);
-loan.set_len(frame_len);
+loan.set_len(frame_len).unwrap();
 loan.publish();
 ```
 
@@ -306,10 +306,10 @@ Requirement: `target_has_atomic = "64"` — the ABA-safe Treiber stack uses 64-b
 
 ```toml
 # no_std + alloc only (protocol core, no ShmPublisher/ShmSubscriber)
-crossbar = { version = "0.2", default-features = false }
+crossbar = { version = "0.3", default-features = false }
 
 # std (default — includes everything)
-crossbar = "0.2"
+crossbar = "0.3"
 ```
 
 ---

--- a/benches/pubsub.rs
+++ b/benches/pubsub.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 // ====================================================
 
 fn bench_pubsub(c: &mut Criterion) {
-    let ps_name = "crossbar-bench-ps";
+    let ps_name = &format!("crossbar-bench-ps-{}", std::process::id());
     let cfg = PubSubConfig {
         block_size: 1_048_576 + 8, // 1 MB data + 8B header
         block_count: 64,
@@ -40,9 +40,9 @@ fn bench_pubsub(c: &mut Criterion) {
         // This is the apples-to-apples iceoryx2 comparison.
         group.bench_function("smart_wake", |b| {
             b.iter(|| {
-                let mut loan = pub_.loan(&h_8b);
+                let mut loan = pub_.loan(&h_8b).unwrap();
                 loan.as_mut_slice()[..8].copy_from_slice(&42u64.to_le_bytes());
-                loan.set_len(8);
+                loan.set_len(8).unwrap();
                 loan.publish(); // smart: no futex since try_recv, not recv
                 let g = s_8b.try_recv().unwrap();
                 black_box(&*g);
@@ -52,9 +52,9 @@ fn bench_pubsub(c: &mut Criterion) {
         // Silent: no notification at all — pure atomics overhead floor.
         group.bench_function("silent_no_wake", |b| {
             b.iter(|| {
-                let mut loan = pub_.loan(&h_8b);
+                let mut loan = pub_.loan(&h_8b).unwrap();
                 loan.as_mut_slice()[..8].copy_from_slice(&42u64.to_le_bytes());
-                loan.set_len(8);
+                loan.set_len(8).unwrap();
                 loan.publish_silent();
                 let g = s_8b.try_recv().unwrap();
                 black_box(&*g);
@@ -72,9 +72,9 @@ fn bench_pubsub(c: &mut Criterion) {
         // 8 bytes — measures pure O(1) transfer overhead
         group.bench_function("8B", |b| {
             b.iter(|| {
-                let mut loan = pub_.loan(&h_8b);
+                let mut loan = pub_.loan(&h_8b).unwrap();
                 loan.as_mut_slice()[..8].copy_from_slice(&42u64.to_le_bytes());
-                loan.set_len(8);
+                loan.set_len(8).unwrap();
                 loan.publish();
                 let g = s_8b.try_recv().unwrap();
                 black_box(&*g); // safe Deref!
@@ -84,9 +84,9 @@ fn bench_pubsub(c: &mut Criterion) {
         // 64 KB — same O(1) ring transfer, different write cost
         group.bench_function("64KB", |b| {
             b.iter(|| {
-                let mut loan = pub_.loan(&h_64kb);
+                let mut loan = pub_.loan(&h_64kb).unwrap();
                 loan.as_mut_slice()[..payload_64kb.len()].copy_from_slice(&payload_64kb);
-                loan.set_len(payload_64kb.len());
+                loan.set_len(payload_64kb.len()).unwrap();
                 loan.publish();
                 let g = s_64kb.try_recv().unwrap();
                 black_box(&*g);
@@ -96,9 +96,9 @@ fn bench_pubsub(c: &mut Criterion) {
         // 1 MB
         group.bench_function("1MB", |b| {
             b.iter(|| {
-                let mut loan = pub_.loan(&h_1mb);
+                let mut loan = pub_.loan(&h_1mb).unwrap();
                 loan.as_mut_slice()[..payload_1mb.len()].copy_from_slice(&payload_1mb);
-                loan.set_len(payload_1mb.len());
+                loan.set_len(payload_1mb.len()).unwrap();
                 loan.publish();
                 let g = s_1mb.try_recv().unwrap();
                 black_box(&*g);
@@ -116,9 +116,9 @@ fn bench_pubsub(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(65_536));
         group.bench_function("64kb", |b| {
             b.iter(|| {
-                let mut loan = pub_.loan(&h_64kb);
+                let mut loan = pub_.loan(&h_64kb).unwrap();
                 loan.as_mut_slice()[..payload_64kb.len()].copy_from_slice(&payload_64kb);
-                loan.set_len(payload_64kb.len());
+                loan.set_len(payload_64kb.len()).unwrap();
                 loan.publish();
                 let g = s_64kb.try_recv().unwrap();
                 black_box(&*g);
@@ -135,9 +135,9 @@ fn bench_pubsub(c: &mut Criterion) {
 
         group.bench_function("1mb", |b| {
             b.iter(|| {
-                let mut loan = pub_.loan(&h_1mb);
+                let mut loan = pub_.loan(&h_1mb).unwrap();
                 loan.as_mut_slice()[..payload_1mb.len()].copy_from_slice(&payload_1mb);
-                loan.set_len(payload_1mb.len());
+                loan.set_len(payload_1mb.len()).unwrap();
                 loan.publish();
                 let g = s_1mb.try_recv().unwrap();
                 black_box(&*g);
@@ -241,9 +241,9 @@ fn bench_iceoryx2_vs_crossbar(c: &mut Criterion) {
 
             group.bench_function(format!("crossbar/8B_on_{label}"), |b| {
                 b.iter(|| {
-                    let mut loan = pub_.loan(&handle);
+                    let mut loan = pub_.loan(&handle).unwrap();
                     loan.as_mut_slice()[..8].copy_from_slice(&42u64.to_le_bytes());
-                    loan.set_len(8);
+                    loan.set_len(8).unwrap();
                     loan.publish();
                     let g = s.try_recv().unwrap();
                     black_box(g[0]); // read 1 byte — O(1)
@@ -327,9 +327,9 @@ fn bench_iceoryx2_vs_crossbar(c: &mut Criterion) {
 
             group.bench_function(format!("crossbar/{label}"), |b| {
                 b.iter(|| {
-                    let mut loan = pub_.loan(handle);
+                    let mut loan = pub_.loan(handle).unwrap();
                     loan.as_mut_slice()[..payload.len()].copy_from_slice(payload);
-                    loan.set_len(payload.len());
+                    loan.set_len(payload.len()).unwrap();
                     loan.publish();
                     let g = sub_handle.try_recv().unwrap();
                     black_box(&*g);
@@ -421,9 +421,9 @@ fn bench_iceoryx2_vs_crossbar(c: &mut Criterion) {
             group.bench_function(format!("crossbar/{label}"), |b| {
                 b.iter(|| {
                     // Pinned: same block every time — L1/L2 warm, no alloc, no refcount
-                    let mut loan = pub_.loan_pinned(handle);
+                    let mut loan = pub_.loan_pinned(handle).unwrap();
                     loan.as_mut_slice()[..sz].fill(42u8);
-                    loan.set_len(sz);
+                    loan.set_len(sz).unwrap();
                     loan.publish();
                     let g = sub_handle.try_recv_pinned().unwrap();
                     black_box(&*g);

--- a/examples/pinned_throughput.rs
+++ b/examples/pinned_throughput.rs
@@ -9,9 +9,9 @@ fn main() {
 
     // Warmup
     for _ in 0..1000 {
-        let mut loan = pub_.loan_pinned(&handle);
+        let mut loan = pub_.loan_pinned(&handle).unwrap();
         loan.as_mut_slice()[..8].copy_from_slice(&42u64.to_le_bytes());
-        loan.set_len(8);
+        loan.set_len(8).unwrap();
         loan.publish();
         let _ = stream.try_recv_pinned();
     }
@@ -20,9 +20,9 @@ fn main() {
     let n = 10_000_000u64;
     let start = Instant::now();
     for i in 0..n {
-        let mut loan = pub_.loan_pinned(&handle);
+        let mut loan = pub_.loan_pinned(&handle).unwrap();
         loan.as_mut_slice()[..8].copy_from_slice(&i.to_le_bytes());
-        loan.set_len(8);
+        loan.set_len(8).unwrap();
         loan.publish();
     }
     let elapsed = start.elapsed();
@@ -36,9 +36,9 @@ fn main() {
     // Measure: full roundtrip
     let start = Instant::now();
     for i in 0..n {
-        let mut loan = pub_.loan_pinned(&handle);
+        let mut loan = pub_.loan_pinned(&handle).unwrap();
         loan.as_mut_slice()[..8].copy_from_slice(&i.to_le_bytes());
-        loan.set_len(8);
+        loan.set_len(8).unwrap();
         loan.publish();
         let g = stream.try_recv_pinned().unwrap();
         std::hint::black_box(&*g);
@@ -53,18 +53,18 @@ fn main() {
 
     // Data throughput at 64KB
     let n_64k = 500_000u64;
+    let cap = pub_.loan_pinned(&handle).unwrap().capacity();
     let start = Instant::now();
     for _ in 0..n_64k {
-        let mut loan = pub_.loan_pinned(&handle);
-        let cap = loan.capacity();
+        let mut loan = pub_.loan_pinned(&handle).unwrap();
         loan.as_mut_slice()[..cap].fill(42u8);
-        loan.set_len(cap);
+        loan.set_len(cap).unwrap();
         loan.publish();
         let g = stream.try_recv_pinned().unwrap();
         std::hint::black_box(&*g);
     }
     let elapsed = start.elapsed();
-    let gb_per_sec = (n_64k as f64 * 65528.0) / elapsed.as_secs_f64() / 1e9;
+    let gb_per_sec = (n_64k as f64 * cap as f64) / elapsed.as_secs_f64() / 1e9;
     let msgs_per_sec = n_64k as f64 / elapsed.as_secs_f64();
     println!(
         "64KB roundtrip:      {:.1} GB/s  {:.0}K msg/s",

--- a/examples/publisher.rs
+++ b/examples/publisher.rs
@@ -53,13 +53,13 @@ fn main() {
     println!("publishing {n} samples at 10µs intervals...");
 
     for i in 0..n {
-        let mut loan = pub_.loan(&handle);
+        let mut loan = pub_.loan(&handle).unwrap();
         let buf = loan.as_mut_slice();
         // Write mono timestamp + sequence directly into SHM
         let ts = mono_nanos();
         buf[0..8].copy_from_slice(&ts.to_le_bytes());
         buf[8..16].copy_from_slice(&i.to_le_bytes());
-        loan.set_len(16);
+        loan.set_len(16).unwrap();
         loan.publish();
 
         // Pace at ~10µs per sample to avoid ring overwrite

--- a/include/crossbar.h
+++ b/include/crossbar.h
@@ -61,8 +61,9 @@ crossbar_topic_t crossbar_publisher_register(
     const char* uri
 );
 
-/* Updates publisher heartbeat. Call during idle periods. */
-void crossbar_publisher_heartbeat(crossbar_publisher_t* pub_);
+/* Updates publisher heartbeat. Call during idle periods.
+   Returns 0 on success, -1 on clock error. */
+int crossbar_publisher_heartbeat(crossbar_publisher_t* pub_);
 
 /* Copies data into a SHM block and publishes. Returns 0 on success. */
 int crossbar_publish(

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,28 @@ pub enum IpcError {
 
     /// The shared-memory region has invalid magic, version, or metadata.
     InvalidRegion(alloc::string::String),
+
+    /// The block pool is exhausted (all blocks are in use by subscribers).
+    PoolExhausted,
+
+    /// Data exceeds the block's data capacity.
+    DataTooLarge {
+        /// Attempted write size.
+        size: usize,
+        /// Block data capacity.
+        capacity: usize,
+    },
+
+    /// A subscriber holds a `PinnedGuard`, preventing the publisher from writing.
+    PinnedReadersActive {
+        /// Number of active readers.
+        count: u32,
+        /// Topic index.
+        topic_idx: u32,
+    },
+
+    /// The system clock is before UNIX epoch (NTP jump, VM restore).
+    ClockError,
 }
 
 impl fmt::Display for IpcError {
@@ -32,6 +54,25 @@ impl fmt::Display for IpcError {
             }
             IpcError::InvalidRegion(msg) => {
                 write!(f, "invalid shared-memory region: {msg}")
+            }
+            IpcError::PoolExhausted => {
+                write!(
+                    f,
+                    "block pool exhausted -- increase block_count in PubSubConfig"
+                )
+            }
+            IpcError::DataTooLarge { size, capacity } => {
+                write!(f, "data ({size}) exceeds block data capacity ({capacity})")
+            }
+            IpcError::PinnedReadersActive { count, topic_idx } => {
+                write!(
+                    f,
+                    "{count} active PinnedGuard(s) on topic {topic_idx} -- \
+                     drop all guards before calling loan_pinned"
+                )
+            }
+            IpcError::ClockError => {
+                write!(f, "system clock is before UNIX epoch")
             }
         }
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -19,7 +19,8 @@ use std::time::Duration;
 use crate::platform::subscription::Subscription;
 use crate::platform::{ShmChannel, ShmPublisher, ShmSubscriber};
 use crate::protocol::layout::BLOCK_DATA_OFFSET;
-use crate::protocol::{PubSubConfig, Region};
+use crate::protocol::PubSubConfig;
+use crate::protocol::{release_block, Region};
 
 // ---- Config ----
 
@@ -77,7 +78,7 @@ fn config_from_ptr(ptr: *const CrossbarConfig) -> PubSubConfig {
 
 // ---- Topic handle ----
 
-/// Value type — safe to copy.
+/// Value type -- safe to copy.
 #[repr(C)]
 pub struct CrossbarTopic {
     /// Topic index within the region.
@@ -97,13 +98,7 @@ pub struct CrossbarSample {
 
 impl Drop for CrossbarSample {
     fn drop(&mut self) {
-        use core::sync::atomic::Ordering;
-        let refcount = self.region.block_refcount(self.block_idx);
-        let prev = refcount.fetch_sub(1, Ordering::Release);
-        if prev == 1 {
-            core::sync::atomic::fence(Ordering::Acquire);
-            self.region.free_block(self.block_idx);
-        }
+        release_block(&self.region, self.block_idx);
     }
 }
 
@@ -113,12 +108,15 @@ impl Drop for CrossbarSample {
 ///
 /// # Safety
 ///
-/// `name` must be a valid null-terminated C string.
+/// `name` must be a valid null-terminated C string, or `NULL`.
 #[no_mangle]
 pub unsafe extern "C" fn crossbar_publisher_create(
     name: *const c_char,
     config: *const CrossbarConfig,
 ) -> *mut ShmPublisher {
+    if name.is_null() {
+        return std::ptr::null_mut();
+    }
     let name = match CStr::from_ptr(name).to_str() {
         Ok(s) => s,
         Err(_) => return std::ptr::null_mut(),
@@ -152,25 +150,24 @@ pub unsafe extern "C" fn crossbar_publisher_register(
     pub_: *mut ShmPublisher,
     uri: *const c_char,
 ) -> CrossbarTopic {
+    let err_topic = CrossbarTopic {
+        topic_idx: u32::MAX,
+        publisher_id: 0,
+    };
+    if pub_.is_null() || uri.is_null() {
+        return err_topic;
+    }
     let pub_ = &mut *pub_;
     let uri = match CStr::from_ptr(uri).to_str() {
         Ok(s) => s,
-        Err(_) => {
-            return CrossbarTopic {
-                topic_idx: u32::MAX,
-                publisher_id: 0,
-            }
-        }
+        Err(_) => return err_topic,
     };
     match pub_.register(uri) {
         Ok(h) => CrossbarTopic {
             topic_idx: h.topic_idx,
             publisher_id: h.publisher_id,
         },
-        Err(_) => CrossbarTopic {
-            topic_idx: u32::MAX,
-            publisher_id: 0,
-        },
+        Err(_) => err_topic,
     }
 }
 
@@ -180,11 +177,17 @@ pub unsafe extern "C" fn crossbar_publisher_register(
 ///
 /// `pub_` must be a valid publisher pointer.
 #[no_mangle]
-pub unsafe extern "C" fn crossbar_publisher_heartbeat(pub_: *mut ShmPublisher) {
-    (*pub_).heartbeat();
+pub unsafe extern "C" fn crossbar_publisher_heartbeat(pub_: *mut ShmPublisher) -> i32 {
+    if pub_.is_null() {
+        return -1;
+    }
+    match (*pub_).heartbeat() {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
 }
 
-/// Copies `data` into a SHM block and publishes it. Returns 0 on success.
+/// Copies `data` into a SHM block and publishes it. Returns 0 on success, -1 on error.
 ///
 /// # Safety
 ///
@@ -198,14 +201,30 @@ pub unsafe extern "C" fn crossbar_publish(
     data: *const u8,
     len: usize,
 ) -> i32 {
+    if pub_.is_null() {
+        return -1;
+    }
     let pub_ = &mut *pub_;
     let handle = crate::platform::loan::TopicHandle {
         topic_idx: topic.topic_idx,
         publisher_id: topic.publisher_id,
     };
-    let mut loan = pub_.loan(&handle);
-    let payload = std::slice::from_raw_parts(data, len);
-    loan.set_data(payload);
+    let mut loan = match pub_.loan(&handle) {
+        Ok(l) => l,
+        Err(_) => return -1,
+    };
+    // Avoid UB: from_raw_parts requires non-null even for len==0
+    let payload = if len == 0 {
+        &[]
+    } else {
+        if data.is_null() {
+            return -1;
+        }
+        std::slice::from_raw_parts(data, len)
+    };
+    if loan.set_data(payload).is_err() {
+        return -1;
+    }
     loan.publish();
     0
 }
@@ -219,6 +238,9 @@ pub unsafe extern "C" fn crossbar_publish(
 /// `name` must be a valid null-terminated C string.
 #[no_mangle]
 pub unsafe extern "C" fn crossbar_subscriber_connect(name: *const c_char) -> *mut ShmSubscriber {
+    if name.is_null() {
+        return std::ptr::null_mut();
+    }
     let name = match CStr::from_ptr(name).to_str() {
         Ok(s) => s,
         Err(_) => return std::ptr::null_mut(),
@@ -252,6 +274,9 @@ pub unsafe extern "C" fn crossbar_subscriber_subscribe(
     sub: *mut ShmSubscriber,
     uri: *const c_char,
 ) -> *mut Subscription {
+    if sub.is_null() || uri.is_null() {
+        return std::ptr::null_mut();
+    }
     let sub = &*sub;
     let uri = match CStr::from_ptr(uri).to_str() {
         Ok(s) => s,
@@ -288,7 +313,7 @@ fn guard_to_sample(
         block_idx: guard.block_idx,
         len: guard.len,
     };
-    // Forget the guard so it doesn't decrement refcount — we took ownership.
+    // Forget the guard so it doesn't decrement refcount -- we took ownership.
     core::mem::forget(guard);
     Box::into_raw(Box::new(sample))
 }
@@ -301,6 +326,9 @@ fn guard_to_sample(
 /// must be freed with `crossbar_sample_free`.
 #[no_mangle]
 pub unsafe extern "C" fn crossbar_try_recv(stream: *mut Subscription) -> *mut CrossbarSample {
+    if stream.is_null() {
+        return std::ptr::null_mut();
+    }
     let stream = &*stream;
     match stream.try_recv() {
         Some(guard) => guard_to_sample(&stream.region, guard),
@@ -310,19 +338,24 @@ pub unsafe extern "C" fn crossbar_try_recv(stream: *mut Subscription) -> *mut Cr
 
 /// Non-blocking receive into caller-provided memory (zero allocation).
 ///
-/// Returns 1 if a sample was written to `out`, 0 if no data available.
-/// The caller must call `crossbar_sample_free` on `out` when done if this
-/// returns 1, or reuse `out` for the next call.
+/// Returns 1 if a sample was written to `out`, 0 if no data available, -1 on error.
+///
+/// **Important:** The caller MUST call `crossbar_sample_free` on `out` before
+/// reusing it if a previous call returned 1. Failing to do so leaks the
+/// previous sample's block.
 ///
 /// # Safety
 ///
 /// `stream` must be a valid subscription pointer. `out` must point to a
-/// valid `CrossbarSample` struct (may be uninitialized).
+/// valid `CrossbarSample` struct (may be uninitialized on first call).
 #[no_mangle]
 pub unsafe extern "C" fn crossbar_try_recv_into(
     stream: *mut Subscription,
     out: *mut CrossbarSample,
 ) -> i32 {
+    if stream.is_null() || out.is_null() {
+        return -1;
+    }
     let stream = &*stream;
     match stream.try_recv() {
         Some(guard) => {
@@ -345,6 +378,9 @@ pub unsafe extern "C" fn crossbar_try_recv_into(
 /// `stream` must be a valid subscription pointer.
 #[no_mangle]
 pub unsafe extern "C" fn crossbar_recv(stream: *mut Subscription) -> *mut CrossbarSample {
+    if stream.is_null() {
+        return std::ptr::null_mut();
+    }
     let stream = &*stream;
     match stream.recv() {
         Ok(guard) => guard_to_sample(&stream.region, guard),
@@ -352,15 +388,22 @@ pub unsafe extern "C" fn crossbar_recv(stream: *mut Subscription) -> *mut Crossb
     }
 }
 
-/// Returns a pointer to the sample's data (zero-copy — points into SHM).
+/// Returns a pointer to the sample's data (zero-copy -- points into SHM).
 ///
 /// # Safety
 ///
 /// `sample` must be a valid sample pointer.
 #[no_mangle]
 pub unsafe extern "C" fn crossbar_sample_data(sample: *const CrossbarSample) -> *const u8 {
+    if sample.is_null() {
+        return std::ptr::null();
+    }
     let s = &*sample;
-    s.region.block_ptr(s.block_idx).add(BLOCK_DATA_OFFSET)
+    // C1: bounds check on block_idx
+    match s.region.block_ptr_checked(s.block_idx) {
+        Some(ptr) => ptr.add(BLOCK_DATA_OFFSET),
+        None => std::ptr::null(),
+    }
 }
 
 /// Returns the sample's data length in bytes.
@@ -370,6 +413,9 @@ pub unsafe extern "C" fn crossbar_sample_data(sample: *const CrossbarSample) -> 
 /// `sample` must be a valid sample pointer.
 #[no_mangle]
 pub unsafe extern "C" fn crossbar_sample_len(sample: *const CrossbarSample) -> usize {
+    if sample.is_null() {
+        return 0;
+    }
     (*sample).len
 }
 
@@ -400,6 +446,9 @@ pub unsafe extern "C" fn crossbar_channel_listen(
     config: *const CrossbarConfig,
     timeout_ms: u64,
 ) -> *mut ShmChannel {
+    if name.is_null() {
+        return std::ptr::null_mut();
+    }
     let name = match CStr::from_ptr(name).to_str() {
         Ok(s) => s,
         Err(_) => return std::ptr::null_mut(),
@@ -426,6 +475,9 @@ pub unsafe extern "C" fn crossbar_channel_connect(
     config: *const CrossbarConfig,
     timeout_ms: u64,
 ) -> *mut ShmChannel {
+    if name.is_null() {
+        return std::ptr::null_mut();
+    }
     let name = match CStr::from_ptr(name).to_str() {
         Ok(s) => s,
         Err(_) => return std::ptr::null_mut(),
@@ -453,7 +505,7 @@ pub unsafe extern "C" fn crossbar_channel_free(ch: *mut ShmChannel) {
     }
 }
 
-/// Sends data through a channel. Returns 0 on success.
+/// Sends data through a channel. Returns 0 on success, -1 on error.
 ///
 /// # Safety
 ///
@@ -464,10 +516,22 @@ pub unsafe extern "C" fn crossbar_channel_send(
     data: *const u8,
     len: usize,
 ) -> i32 {
+    if ch.is_null() {
+        return -1;
+    }
     let ch = &mut *ch;
-    let payload = std::slice::from_raw_parts(data, len);
-    ch.send(payload);
-    0
+    let payload = if len == 0 {
+        &[]
+    } else {
+        if data.is_null() {
+            return -1;
+        }
+        std::slice::from_raw_parts(data, len)
+    };
+    match ch.send(payload) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
 }
 
 /// Non-blocking receive on a channel. Returns `NULL` if no data.
@@ -477,11 +541,12 @@ pub unsafe extern "C" fn crossbar_channel_send(
 /// `ch` must be a valid channel pointer.
 #[no_mangle]
 pub unsafe extern "C" fn crossbar_channel_try_recv(ch: *mut ShmChannel) -> *mut CrossbarSample {
+    if ch.is_null() {
+        return std::ptr::null_mut();
+    }
     let ch = &*ch;
     match ch.try_recv() {
         Some(guard) => {
-            // Channel's subscription holds the Arc<Region>. We need to access
-            // it to create a self-owned sample. Access via the guard's region ref.
             let sample = CrossbarSample {
                 region: Arc::clone(&ch.rx.region),
                 block_idx: guard.block_idx,
@@ -501,6 +566,9 @@ pub unsafe extern "C" fn crossbar_channel_try_recv(ch: *mut ShmChannel) -> *mut 
 /// `ch` must be a valid channel pointer.
 #[no_mangle]
 pub unsafe extern "C" fn crossbar_channel_recv(ch: *mut ShmChannel) -> *mut CrossbarSample {
+    if ch.is_null() {
+        return std::ptr::null_mut();
+    }
     let ch = &*ch;
     match ch.recv() {
         Ok(guard) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@
 //! let mut pub_ = ShmPublisher::create("prices", PubSubConfig::default()).unwrap();
 //! let topic = pub_.register("/tick/AAPL").unwrap();
 //!
-//! let mut loan = pub_.loan(&topic);
-//! loan.set_data(b"hello");
+//! let mut loan = pub_.loan(&topic).unwrap();
+//! loan.set_data(b"hello").unwrap();
 //! loan.publish(); // O(1) — writes 8 bytes to ring
 //! ```
 
@@ -39,10 +39,8 @@ extern crate alloc;
 
 #[allow(unsafe_code)]
 mod pod;
-#[cfg_attr(not(feature = "std"), allow(dead_code))]
 #[allow(unsafe_code)]
 pub mod protocol;
-#[cfg_attr(not(feature = "std"), allow(dead_code))]
 #[allow(unsafe_code)]
 pub mod wait;
 

--- a/src/platform/channel.rs
+++ b/src/platform/channel.rs
@@ -19,7 +19,7 @@ use super::subscription::{SampleGuard, Subscription};
 
 /// Bidirectional shared-memory channel.
 ///
-/// Composed of two pub/sub regions — one per direction. The server creates
+/// Composed of two pub/sub regions -- one per direction. The server creates
 /// `"{name}-srv"` and subscribes to `"{name}-cli"`; the client does the
 /// reverse. Both endpoints have identical capabilities after construction.
 ///
@@ -29,7 +29,7 @@ use super::subscription::{SampleGuard, Subscription};
 /// use crossbar::*;
 /// use std::time::Duration;
 ///
-/// // Process A (server — start first)
+/// // Process A (server -- start first)
 /// let mut srv = ShmChannel::listen("rpc", PubSubConfig::default(),
 ///     Duration::from_secs(30)).unwrap();
 ///
@@ -37,12 +37,12 @@ use super::subscription::{SampleGuard, Subscription};
 /// let mut cli = ShmChannel::connect("rpc", PubSubConfig::default(),
 ///     Duration::from_secs(5)).unwrap();
 ///
-/// cli.send(b"request");
+/// cli.send(b"request").unwrap();
 /// let msg = srv.recv().unwrap();
 /// assert_eq!(&*msg, b"request");
 /// drop(msg);
 ///
-/// srv.send(b"response");
+/// srv.send(b"response").unwrap();
 /// let reply = cli.recv().unwrap();
 /// assert_eq!(&*reply, b"response");
 /// ```
@@ -51,6 +51,12 @@ pub struct ShmChannel {
     tx_topic: TopicHandle,
     _rx_sub: ShmSubscriber, // keeps mmap alive
     pub(crate) rx: Subscription,
+}
+
+impl core::fmt::Debug for ShmChannel {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ShmChannel").field("rx", &self.rx).finish()
+    }
 }
 
 impl ShmChannel {
@@ -103,19 +109,25 @@ impl ShmChannel {
 
     /// Copies `data` into a pool block and sends it to the other endpoint.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the pool is exhausted or `data` exceeds block capacity.
-    pub fn send(&mut self, data: &[u8]) {
-        let mut loan = self.tx_pub.loan(&self.tx_topic);
-        loan.set_data(data);
+    /// Returns [`IpcError::PoolExhausted`] if all blocks are in use, or
+    /// [`IpcError::DataTooLarge`] if `data` exceeds block capacity.
+    pub fn send(&mut self, data: &[u8]) -> Result<(), IpcError> {
+        let mut loan = self.tx_pub.loan(&self.tx_topic)?;
+        loan.set_data(data)?;
         loan.publish();
+        Ok(())
     }
 
     /// Returns a mutable loan for born-in-SHM writes.
     ///
     /// Write directly into the loan, then call [`ShmLoan::publish`].
-    pub fn loan(&mut self) -> ShmLoan<'_> {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IpcError::PoolExhausted`] if all blocks are in use.
+    pub fn loan(&mut self) -> Result<ShmLoan<'_>, IpcError> {
         self.tx_pub.loan(&self.tx_topic)
     }
 
@@ -147,8 +159,12 @@ impl ShmChannel {
 
     /// Updates the publisher heartbeat. Call during idle periods when
     /// not sending to prevent the other side from reporting publisher dead.
-    pub fn heartbeat(&mut self) {
-        self.tx_pub.heartbeat();
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IpcError::ClockError`] if the system clock is before UNIX epoch.
+    pub fn heartbeat(&mut self) -> Result<(), IpcError> {
+        self.tx_pub.heartbeat()
     }
 }
 
@@ -170,11 +186,11 @@ fn wait_for_peer(
         match ShmSubscriber::connect(region_name) {
             Ok(sub) => match sub.subscribe("/ch") {
                 Ok(rx) => {
-                    // Start from beginning — channel must not miss early messages.
+                    // Start from beginning -- channel must not miss early messages.
                     rx.last_seq.set(0);
                     return Ok((sub, rx));
                 }
-                // Topic not registered yet — retry
+                // Topic not registered yet -- retry
                 Err(_) if deadline.is_some_and(|d| std::time::Instant::now() < d) => {
                     std::thread::sleep(Duration::from_millis(10));
                 }

--- a/src/platform/loan.rs
+++ b/src/platform/loan.rs
@@ -10,6 +10,7 @@ use std::io;
 use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::Arc;
 
+use crate::error::IpcError;
 use crate::protocol::layout::BLOCK_DATA_OFFSET;
 use crate::protocol::Region;
 
@@ -25,7 +26,6 @@ use crate::protocol::Region;
 /// `src` and `dst` must be valid for `len` bytes and must not overlap.
 #[cfg(target_arch = "x86_64")]
 unsafe fn nontemporal_copy(src: *const u8, dst: *mut u8, len: usize) {
-    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{__m128i, _mm_loadu_si128, _mm_sfence, _mm_stream_si128};
 
     let mut offset = 0usize;
@@ -57,7 +57,7 @@ unsafe fn nontemporal_copy(src: *const u8, dst: *mut u8, len: usize) {
 
 /// Handle returned by [`super::shm::ShmPublisher::register`]. Identifies a topic
 /// for use with [`super::shm::ShmPublisher::loan`].
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TopicHandle {
     pub(crate) topic_idx: u32,
     pub(crate) publisher_id: u64,
@@ -93,16 +93,16 @@ impl<'a> ShmLoan<'a> {
 
     /// Copies `data` into the block starting at offset 0.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `data` exceeds the block's data capacity.
-    pub fn set_data(&mut self, data: &[u8]) {
-        assert!(
-            data.len() <= self.capacity,
-            "data ({}) exceeds block data capacity ({})",
-            data.len(),
-            self.capacity
-        );
+    /// Returns [`IpcError::DataTooLarge`] if `data` exceeds block data capacity.
+    pub fn set_data(&mut self, data: &[u8]) -> Result<(), IpcError> {
+        if data.len() > self.capacity {
+            return Err(IpcError::DataTooLarge {
+                size: data.len(),
+                capacity: self.capacity,
+            });
+        }
         #[cfg(target_arch = "x86_64")]
         {
             if data.len() >= 2_097_152 {
@@ -111,19 +111,30 @@ impl<'a> ShmLoan<'a> {
                 // from their own cache lines.
                 unsafe { nontemporal_copy(data.as_ptr(), self.data_ptr, data.len()) };
                 self.len = data.len();
-                return;
+                return Ok(());
             }
         }
         unsafe {
             core::ptr::copy_nonoverlapping(data.as_ptr(), self.data_ptr, data.len());
         }
         self.len = data.len();
+        Ok(())
     }
 
     /// Sets the valid data length (use after writing via `as_mut_slice`).
-    pub fn set_len(&mut self, len: usize) {
-        assert!(len <= self.capacity);
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IpcError::DataTooLarge`] if `len` exceeds block data capacity.
+    pub fn set_len(&mut self, len: usize) -> Result<(), IpcError> {
+        if len > self.capacity {
+            return Err(IpcError::DataTooLarge {
+                size: len,
+                capacity: self.capacity,
+            });
+        }
         self.len = len;
+        Ok(())
     }
 
     /// Maximum bytes this loan can hold.
@@ -149,6 +160,9 @@ impl<'a> ShmLoan<'a> {
 
     #[inline]
     fn commit(&self, wake: bool) {
+        // Runtime check: len must fit in u32 (structurally enforced by u32 block_size,
+        // but defense-in-depth against corruption via io::Write accumulation)
+        assert!(self.len <= u32::MAX as usize, "data_len overflow");
         self.region.commit_to_ring(
             self.block_idx,
             self.len as u32,
@@ -274,11 +288,10 @@ impl<T: crate::Pod> Drop for TypedShmLoan<'_, T> {
 /// The block is permanently assigned to the topic -- no allocation on loan,
 /// no refcount. `publish()` is a single atomic Release store.
 ///
-/// # Safety
+/// # Panics
 ///
-/// Subscribers MUST NOT hold a [`PinnedGuard`](super::subscription::PinnedGuard)
-/// for this topic while the publisher holds a `PinnedLoan`. Overlapping
-/// reads and writes are undefined behavior.
+/// `loan_pinned` returns an error if subscribers hold a `PinnedGuard`.
+/// Overlapping reads and writes are prevented at runtime.
 pub struct PinnedLoan<'a> {
     pub(crate) region: &'a Arc<Region>,
     pub(crate) data_ptr: *mut u8,
@@ -287,6 +300,7 @@ pub struct PinnedLoan<'a> {
     pub(crate) topic_idx: u32,
     pub(crate) write_seq_atom: &'a AtomicU64,
     pub(crate) waiters_atom: &'a AtomicU32,
+    pub(crate) readers: &'a AtomicU32,
 }
 
 impl<'a> PinnedLoan<'a> {
@@ -296,18 +310,38 @@ impl<'a> PinnedLoan<'a> {
     }
 
     /// Copies `data` into the block starting at offset 0.
-    pub fn set_data(&mut self, data: &[u8]) {
-        assert!(data.len() <= self.capacity);
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IpcError::DataTooLarge`] if `data` exceeds block data capacity.
+    pub fn set_data(&mut self, data: &[u8]) -> Result<(), IpcError> {
+        if data.len() > self.capacity {
+            return Err(IpcError::DataTooLarge {
+                size: data.len(),
+                capacity: self.capacity,
+            });
+        }
         unsafe {
             core::ptr::copy_nonoverlapping(data.as_ptr(), self.data_ptr, data.len());
         }
         self.len = data.len();
+        Ok(())
     }
 
     /// Sets the valid data length.
-    pub fn set_len(&mut self, len: usize) {
-        assert!(len <= self.capacity);
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IpcError::DataTooLarge`] if `len` exceeds block data capacity.
+    pub fn set_len(&mut self, len: usize) -> Result<(), IpcError> {
+        if len > self.capacity {
+            return Err(IpcError::DataTooLarge {
+                size: len,
+                capacity: self.capacity,
+            });
+        }
         self.len = len;
+        Ok(())
     }
 
     /// Maximum bytes this loan can hold.
@@ -315,19 +349,29 @@ impl<'a> PinnedLoan<'a> {
         self.capacity
     }
 
-    /// Publish. 1 atomic Release store -- that's it.
-    ///
-    /// # Safety
-    ///
-    /// No subscriber may hold a `PinnedGuard` for this topic.
+    /// Publish. 1 atomic Release store + clear writer sentinel.
     #[inline]
     pub fn publish(self) {
+        assert!(self.len <= u32::MAX as usize, "data_len overflow");
         self.region.commit_pinned(
             self.len as u32,
             self.topic_idx,
             self.write_seq_atom,
             self.waiters_atom,
         );
-        // No mem::forget needed -- PinnedLoan has no Drop.
+        // Clear the writer sentinel so subscribers can enter again
+        self.readers.store(0, core::sync::atomic::Ordering::Release);
+        // Skip Drop — we already cleared the sentinel
+        core::mem::forget(self);
+    }
+}
+
+impl Drop for PinnedLoan<'_> {
+    fn drop(&mut self) {
+        // PinnedLoan dropped without publish — clear the writer sentinel
+        // so subscribers aren't permanently blocked. Data in the pinned
+        // block is stale (partial write), but the old pinned_seq is still
+        // valid so subscribers won't see the partial data.
+        self.readers.store(0, core::sync::atomic::Ordering::Release);
     }
 }

--- a/src/platform/mmap.rs
+++ b/src/platform/mmap.rs
@@ -57,7 +57,7 @@ unsafe impl Sync for RawMmap {}
 impl RawMmap {
     /// Maps `file` read-write using the file's current size.
     ///
-    /// Applies `MAP_SHARED | MAP_POPULATE` and `MADV_HUGEPAGE` on Linux.
+    /// Applies `MAP_SHARED` and `MADV_HUGEPAGE` on Linux.
     pub fn from_file(file: &std::fs::File) -> io::Result<Self> {
         let len = file.metadata()?.len() as usize;
         Self::from_file_with_len(file, len)

--- a/src/platform/notify.rs
+++ b/src/platform/notify.rs
@@ -45,8 +45,7 @@ pub fn wait_until_not(
             // x86: PAUSE yields the pipeline to the SMT sibling (~140 cycles).
             #[cfg(target_arch = "aarch64")]
             unsafe {
-                core::arch::asm!("sevl", options(nomem, nostack));
-                core::arch::asm!("wfe", options(nomem, nostack));
+                core::arch::asm!("sevl", "wfe", options(nomem, nostack));
             }
             #[cfg(not(target_arch = "aarch64"))]
             core::hint::spin_loop();

--- a/src/platform/shm.rs
+++ b/src/platform/shm.rs
@@ -8,6 +8,7 @@
 
 use alloc::format;
 use alloc::string::ToString;
+use alloc::vec;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -37,6 +38,16 @@ fn lock_path(name: &str) -> PathBuf {
     let mut p = shm_path(name);
     p.set_extension("lock");
     p
+}
+
+/// Validate segment name against path traversal (C2).
+fn validate_name(name: &str) -> Result<(), IpcError> {
+    if !is_valid_segment_name(name) {
+        return Err(IpcError::InvalidRegion(format!(
+            "invalid segment name '{name}': must be non-empty and contain no '/', '\\\\', '..', or null bytes"
+        )));
+    }
+    Ok(())
 }
 
 /// Acquire an exclusive, non-blocking lock on `file`.
@@ -95,11 +106,14 @@ fn shared_lock(file: &std::fs::File, name: &str) -> Result<(), IpcError> {
 }
 
 /// Acquire or downgrade to a shared lock on `file`.
+/// Note: Windows has no atomic downgrade. There is a brief unlock window
+/// between releasing the exclusive lock and acquiring the shared lock.
 #[cfg(windows)]
 fn shared_lock(file: &std::fs::File, name: &str) -> Result<(), IpcError> {
     use std::os::windows::io::AsRawHandle;
     let handle = file.as_raw_handle();
     // Unlock first (no atomic downgrade on Windows), then reacquire as shared.
+    // TOCTOU gap: another process could acquire exclusive between these calls.
     let mut overlapped: windows_sys::Win32::System::IO::OVERLAPPED = unsafe { std::mem::zeroed() };
     unsafe {
         windows_sys::Win32::Storage::FileSystem::UnlockFileEx(
@@ -131,21 +145,18 @@ fn shared_lock(file: &std::fs::File, name: &str) -> Result<(), IpcError> {
 
 /// Returns a stable numeric identity for the file at `path`.
 /// Uses inode on Unix, file index on Windows.
+/// Returns `None` on error (prevents accidental deletion of wrong file).
 #[cfg(unix)]
-fn file_identity(path: &std::path::Path) -> u64 {
+fn file_identity(path: &std::path::Path) -> Option<u64> {
     use std::os::unix::fs::MetadataExt;
-    std::fs::metadata(path).map(|m| m.ino()).unwrap_or(0)
+    std::fs::metadata(path).map(|m| m.ino()).ok()
 }
 
 /// Returns a stable numeric identity for the file at `path`.
-/// Uses inode on Unix, file index on Windows.
 #[cfg(windows)]
-fn file_identity(path: &std::path::Path) -> u64 {
+fn file_identity(path: &std::path::Path) -> Option<u64> {
     use std::os::windows::io::AsRawHandle;
-    let file = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return 0,
-    };
+    let file = std::fs::File::open(path).ok()?;
     let handle = file.as_raw_handle();
     let mut info: windows_sys::Win32::Storage::FileSystem::BY_HANDLE_FILE_INFORMATION =
         unsafe { std::mem::zeroed() };
@@ -153,9 +164,129 @@ fn file_identity(path: &std::path::Path) -> u64 {
         windows_sys::Win32::Storage::FileSystem::GetFileInformationByHandle(handle, &mut info)
     };
     if ok == 0 {
-        return 0;
+        return None;
     }
-    (info.nFileIndexHigh as u64) << 32 | info.nFileIndexLow as u64
+    Some((info.nFileIndexHigh as u64) << 32 | info.nFileIndexLow as u64)
+}
+
+/// Generate a unique publisher ID using PID + atomic counter + thread ID hash.
+fn generate_publisher_id() -> u64 {
+    use core::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = u64::from(std::process::id());
+    // Combine PID, monotonic counter, and thread ID for uniqueness
+    let thread_hash = {
+        let id = std::thread::current().id();
+        // Thread IDs are opaque, hash via Debug formatting
+        let s = alloc::format!("{id:?}");
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+        for b in s.as_bytes() {
+            h ^= u64::from(*b);
+            h = h.wrapping_mul(0x0100_0000_01b3);
+        }
+        h
+    };
+    pid ^ seq ^ thread_hash
+}
+
+/// Shared logic for opening and validating an existing SHM region.
+/// Used by both `ShmPublisher::open()` and `ShmSubscriber::connect()`.
+fn open_and_validate_region(
+    name: &str,
+    needs_write: bool,
+) -> Result<(RawMmap, Arc<Region>, PathBuf), IpcError> {
+    let path = shm_path(name);
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(needs_write) // needed for atomic CAS on refcounts
+        .open(&path)
+        .map_err(IpcError::Io)?;
+
+    let mmap = RawMmap::from_file(&file).map_err(IpcError::Io)?;
+
+    if mmap.len() < HEADER_SIZE {
+        return Err(IpcError::InvalidRegion(
+            "region too small for header".into(),
+        ));
+    }
+
+    // Validate header
+    let ptr = mmap.as_ptr();
+    unsafe {
+        let mut magic = [0u8; 8];
+        core::ptr::copy_nonoverlapping(ptr.add(GH_MAGIC), magic.as_mut_ptr(), 8);
+        if &magic != MAGIC {
+            return Err(IpcError::InvalidRegion(
+                "invalid magic (expected XBAR_ZC)".into(),
+            ));
+        }
+        let ver = (ptr.add(GH_VERSION) as *const u32).read();
+        if ver != VERSION {
+            return Err(IpcError::InvalidRegion(format!(
+                "unsupported version {ver}, expected {VERSION}"
+            )));
+        }
+    }
+
+    // Read config from header
+    let config = unsafe {
+        PubSubConfig {
+            max_topics: (ptr.add(GH_MAX_TOPICS) as *const u32).read(),
+            block_count: (ptr.add(GH_BLOCK_COUNT) as *const u32).read(),
+            block_size: (ptr.add(GH_BLOCK_SIZE) as *const u32).read(),
+            ring_depth: (ptr.add(GH_RING_DEPTH) as *const u32).read(),
+            stale_timeout: Duration::from_micros(
+                (ptr.add(GH_STALE_TIMEOUT_US) as *const u64).read(),
+            ),
+            ..PubSubConfig::default()
+        }
+    };
+
+    // Validate config read from SHM header (H5: defense against malicious header)
+    if config.block_size < BLOCK_DATA_OFFSET as u32 + 1 {
+        return Err(IpcError::InvalidRegion(format!(
+            "header block_size {} too small",
+            config.block_size
+        )));
+    }
+    if !config.ring_depth.is_power_of_two() || config.ring_depth == 0 {
+        return Err(IpcError::InvalidRegion(format!(
+            "header ring_depth {} is not a power of 2",
+            config.ring_depth
+        )));
+    }
+    if config.block_count == 0 {
+        return Err(IpcError::InvalidRegion("header block_count is 0".into()));
+    }
+    if config.max_topics == 0 {
+        return Err(IpcError::InvalidRegion("header max_topics is 0".into()));
+    }
+    if config.max_topics > MAX_TOPICS_LIMIT {
+        return Err(IpcError::InvalidRegion(format!(
+            "header max_topics {} exceeds limit {MAX_TOPICS_LIMIT}",
+            config.max_topics
+        )));
+    }
+
+    // Use checked arithmetic to prevent overflow (M6)
+    let expected_size = region_size_checked(&config)
+        .ok_or_else(|| IpcError::InvalidRegion("region size computation overflow".into()))?;
+
+    if mmap.len() < expected_size {
+        return Err(IpcError::InvalidRegion(format!(
+            "region size {} < expected {expected_size}",
+            mmap.len()
+        )));
+    }
+
+    // SAFETY: mmap provides a valid region of the computed size.
+    let region = Arc::new(unsafe { Region::from_raw(mmap.as_mut_ptr(), mmap.len(), config) });
+
+    region.check_heartbeat()?;
+
+    Ok((mmap, region, path))
 }
 
 // ---- ShmPublisher ----
@@ -174,9 +305,9 @@ fn file_identity(path: &std::path::Path) -> u64 {
 /// let mut pub_ = ShmPublisher::create("prices", PubSubConfig::default()).unwrap();
 /// let topic = pub_.register("/tick/AAPL").unwrap();
 ///
-/// let mut loan = pub_.loan(&topic);
+/// let mut loan = pub_.loan(&topic).unwrap();
 /// loan.as_mut_slice()[..8].copy_from_slice(&42u64.to_le_bytes());
-/// loan.set_len(8);
+/// loan.set_len(8).unwrap();
 /// loan.publish(); // O(1) -- writes 8 bytes to ring
 /// ```
 pub struct ShmPublisher {
@@ -184,14 +315,14 @@ pub struct ShmPublisher {
     region: Arc<Region>,
     path: PathBuf,
     _lock_file: Option<std::fs::File>,
-    created_ino: u64,
+    created_ino: Option<u64>,
     is_owner: bool,
     id: u64,
     last_heartbeat: std::time::Instant,
     loan_count: u32,
     block_cache: [u32; 8],
     cache_len: u8,
-    pinned_blocks: [u32; 16], // block_idx per topic_idx, NO_BLOCK if not pinned
+    pinned_blocks: alloc::vec::Vec<u32>,
 }
 
 impl ShmPublisher {
@@ -225,6 +356,33 @@ impl ShmPublisher {
         }
     }
 
+    /// Shared preamble for `loan` and `loan_typed`: heartbeat check + block alloc.
+    /// Returns (block_idx, topic_idx). Atomic refs are computed by the caller
+    /// from `self.region` to avoid borrow conflicts.
+    fn loan_preamble(&mut self, handle: &TopicHandle) -> Result<(u32, u32), IpcError> {
+        // Runtime check: reject handles from a different publisher (Codex HIGH)
+        if handle.publisher_id != self.id {
+            return Err(IpcError::InvalidRegion(
+                "TopicHandle belongs to a different ShmPublisher".into(),
+            ));
+        }
+
+        // Counter-based heartbeat: check clock every 1024 loans, not every loan.
+        self.loan_count = self.loan_count.wrapping_add(1);
+        if self.loan_count & 0x3FF == 0
+            && self.last_heartbeat.elapsed() >= self.region.config.heartbeat_interval
+        {
+            // Only advance last_heartbeat if the update succeeded
+            if self.region.update_heartbeat().is_ok() {
+                self.last_heartbeat = std::time::Instant::now();
+            }
+        }
+
+        let block_idx = self.alloc_cached().ok_or(IpcError::PoolExhausted)?;
+
+        Ok((block_idx, handle.topic_idx))
+    }
+
     /// Creates a new pool-backed pub/sub region.
     ///
     /// # Errors
@@ -232,6 +390,9 @@ impl ShmPublisher {
     /// Returns [`IpcError::Io`] if the backing file cannot be created,
     /// or [`IpcError::InvalidRegion`] if another publisher is active.
     pub fn create(name: &str, config: PubSubConfig) -> Result<Self, IpcError> {
+        // Validate segment name against path traversal (C2)
+        validate_name(name)?;
+
         // Validate config to prevent panics from invalid values
         if config.block_size < BLOCK_DATA_OFFSET as u32 + 1 {
             return Err(IpcError::InvalidRegion(format!(
@@ -257,16 +418,23 @@ impl ShmPublisher {
             ));
         }
 
+        // Check for overflow in region size computation (M6)
+        let size = region_size_checked(&config)
+            .ok_or_else(|| IpcError::InvalidRegion("region size computation overflow".into()))?;
+
         let path = shm_path(name);
         let lpath = lock_path(name);
 
-        let lock_file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&lpath)
-            .map_err(IpcError::Io)?;
+        let lock_file = {
+            let mut opts = std::fs::OpenOptions::new();
+            opts.read(true).write(true).create(true).truncate(false);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600); // H8: restrictive permissions
+            }
+            opts.open(&lpath).map_err(IpcError::Io)?
+        };
 
         // Exclusive lock -- only one publisher per region
         exclusive_lock(&lock_file, name)?;
@@ -274,14 +442,16 @@ impl ShmPublisher {
         // Remove stale file
         let _ = std::fs::remove_file(&path);
 
-        let size = region_size(&config);
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&path)
-            .map_err(IpcError::Io)?;
+        let file = {
+            let mut opts = std::fs::OpenOptions::new();
+            opts.read(true).write(true).create(true).truncate(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600); // H8: restrictive permissions
+            }
+            opts.open(&path).map_err(IpcError::Io)?
+        };
         file.set_len(size as u64).map_err(IpcError::Io)?;
 
         let mmap = RawMmap::from_file_with_len(&file, size).map_err(IpcError::Io)?;
@@ -297,6 +467,7 @@ impl ShmPublisher {
             (ptr.add(GH_RING_DEPTH) as *mut u32).write(config.ring_depth);
             let pid = u64::from(std::process::id());
             (ptr.add(GH_PID) as *mut u64).write(pid);
+            #[allow(clippy::cast_possible_truncation)]
             (ptr.add(GH_STALE_TIMEOUT_US) as *mut u64)
                 .write(config.stale_timeout.as_micros() as u64);
         }
@@ -306,7 +477,7 @@ impl ShmPublisher {
 
         // Initialize pool free list
         region.init_free_list();
-        region.update_heartbeat();
+        region.update_heartbeat()?;
 
         // Initialize all ring entries to NO_BLOCK
         for t in 0..config.max_topics {
@@ -327,13 +498,7 @@ impl ShmPublisher {
         shared_lock(&lock_file, name)?;
 
         let created_ino = file_identity(&path);
-
-        #[allow(clippy::cast_possible_truncation)]
-        let id = u64::from(std::process::id())
-            ^ (std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos() as u64);
+        let id = generate_publisher_id();
 
         Ok(ShmPublisher {
             _mmap: mmap,
@@ -347,7 +512,7 @@ impl ShmPublisher {
             loan_count: 0,
             block_cache: [0; 8],
             cache_len: 0,
-            pinned_blocks: [NO_BLOCK; 16],
+            pinned_blocks: vec![NO_BLOCK; config.max_topics as usize],
         })
     }
 
@@ -362,7 +527,8 @@ impl ShmPublisher {
     /// Returns an error if the region file doesn't exist, has invalid
     /// magic/version, or the publisher's heartbeat is stale.
     pub fn open(name: &str) -> Result<Self, IpcError> {
-        let path = shm_path(name);
+        validate_name(name)?;
+
         let lpath = lock_path(name);
 
         // Acquire a shared lock on the lock file. This prevents a new
@@ -376,85 +542,23 @@ impl ShmPublisher {
             .map_err(IpcError::Io)?;
         shared_lock(&lock_file, name)?;
 
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true) // needed for atomic CAS on refcounts
-            .open(&path)
-            .map_err(IpcError::Io)?;
-
-        let mmap = RawMmap::from_file(&file).map_err(IpcError::Io)?;
-
-        if mmap.len() < HEADER_SIZE {
-            return Err(IpcError::InvalidRegion(
-                "region too small for header".into(),
-            ));
-        }
-
-        // Validate header
-        let ptr = mmap.as_ptr();
-        unsafe {
-            let mut magic = [0u8; 8];
-            core::ptr::copy_nonoverlapping(ptr.add(GH_MAGIC), magic.as_mut_ptr(), 8);
-            if &magic != MAGIC {
-                return Err(IpcError::InvalidRegion(
-                    "invalid magic (expected XBAR_ZC)".into(),
-                ));
-            }
-            let ver = (ptr.add(GH_VERSION) as *const u32).read();
-            if ver != VERSION {
-                return Err(IpcError::InvalidRegion(format!(
-                    "unsupported version {ver}, expected {VERSION}"
-                )));
-            }
-        }
-
-        // Read config from header
-        let config = unsafe {
-            PubSubConfig {
-                max_topics: (ptr.add(GH_MAX_TOPICS) as *const u32).read(),
-                block_count: (ptr.add(GH_BLOCK_COUNT) as *const u32).read(),
-                block_size: (ptr.add(GH_BLOCK_SIZE) as *const u32).read(),
-                ring_depth: (ptr.add(GH_RING_DEPTH) as *const u32).read(),
-                stale_timeout: Duration::from_micros(
-                    (ptr.add(GH_STALE_TIMEOUT_US) as *const u64).read(),
-                ),
-                ..PubSubConfig::default()
-            }
-        };
-
-        let expected_size = region_size(&config);
-        if mmap.len() < expected_size {
-            return Err(IpcError::InvalidRegion(format!(
-                "region size {} < expected {expected_size}",
-                mmap.len()
-            )));
-        }
-
-        // SAFETY: mmap provides a valid region of the computed size.
-        let region = Arc::new(unsafe { Region::from_raw(mmap.as_mut_ptr(), mmap.len(), config) });
-
-        region.check_heartbeat()?;
-
-        #[allow(clippy::cast_possible_truncation)]
-        let id = u64::from(std::process::id())
-            ^ (std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos() as u64);
+        let (mmap, region, path) = open_and_validate_region(name, true)?;
+        let id = generate_publisher_id();
+        let max_topics = region.config.max_topics;
 
         Ok(ShmPublisher {
             _mmap: mmap,
             region,
             path,
             _lock_file: Some(lock_file),
-            created_ino: 0,
+            created_ino: None,
             is_owner: false,
             id,
             last_heartbeat: std::time::Instant::now(),
             loan_count: 0,
             block_cache: [0; 8],
             cache_len: 0,
-            pinned_blocks: [NO_BLOCK; 16],
+            pinned_blocks: vec![NO_BLOCK; max_topics as usize],
         })
     }
 
@@ -474,20 +578,18 @@ impl ShmPublisher {
     /// The type size is stored in the topic entry so that subscribers can
     /// verify the expected type size at receive time.
     ///
-    /// # Panics
-    ///
-    /// Panics if `T`'s alignment exceeds 8 (the block data offset).
-    ///
     /// # Errors
     ///
-    /// Returns an error if the maximum number of topics has been reached
-    /// or the URI exceeds 64 bytes.
+    /// Returns an error if `T`'s alignment exceeds 8, the maximum number
+    /// of topics has been reached, or the URI exceeds 64 bytes.
     pub fn register_typed<T: crate::Pod>(&mut self, uri: &str) -> Result<TopicHandle, IpcError> {
-        assert!(
-            core::mem::align_of::<T>() <= 8,
-            "Pod type alignment ({}) exceeds block data offset (8)",
-            core::mem::align_of::<T>()
-        );
+        const { assert!(core::mem::align_of::<u128>() <= 16) }; // sanity
+        if core::mem::align_of::<T>() > 8 {
+            return Err(IpcError::InvalidRegion(format!(
+                "Pod type alignment ({}) exceeds block data offset (8)",
+                core::mem::align_of::<T>()
+            )));
+        }
         self.register_inner(uri, core::mem::size_of::<T>() as u32)
     }
 
@@ -500,7 +602,7 @@ impl ShmPublisher {
         }
         let hash = uri_hash(uri);
 
-        let base_ptr = self.region.base;
+        let base_ptr = self.region.base_ptr();
 
         // Phase 1: Scan for existing topic (check active==ACTIVE slots for URI match)
         for i in 0..self.region.config.max_topics {
@@ -579,9 +681,15 @@ impl ShmPublisher {
     ///
     /// `loan()` updates the heartbeat automatically every 1024 calls, so you
     /// only need this if the publisher may be idle longer than `stale_timeout`.
-    pub fn heartbeat(&mut self) {
-        self.region.update_heartbeat();
+    /// Updates the publisher heartbeat.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IpcError::ClockError`] if the system clock is before UNIX epoch.
+    pub fn heartbeat(&mut self) -> Result<(), IpcError> {
+        self.region.update_heartbeat()?;
         self.last_heartbeat = std::time::Instant::now();
+        Ok(())
     }
 
     /// Loans a block from the pool for writing. Write your data, then call
@@ -590,45 +698,19 @@ impl ShmPublisher {
     /// If the loan is dropped without publishing, the block is returned to
     /// the pool automatically.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the pool is exhausted (all blocks in use) or if the handle
-    /// belongs to a different publisher.
+    /// Returns [`IpcError::PoolExhausted`] if all blocks are in use.
     #[inline]
-    pub fn loan(&mut self, handle: &TopicHandle) -> ShmLoan<'_> {
-        debug_assert_eq!(
-            handle.publisher_id, self.id,
-            "TopicHandle belongs to a different ShmPublisher"
-        );
-
-        // Counter-based heartbeat: check clock every 1024 loans, not every loan.
-        // Saves ~20ns per loan by avoiding Instant::now() on the hot path.
-        // All publishers update the heartbeat — it signals "region is alive",
-        // not "primary is alive". fetch_max in update_heartbeat() handles races.
-        self.loan_count = self.loan_count.wrapping_add(1);
-        if self.loan_count & 0x3FF == 0
-            && self.last_heartbeat.elapsed() >= self.region.config.heartbeat_interval
-        {
-            self.region.update_heartbeat();
-            self.last_heartbeat = std::time::Instant::now();
-        }
-
-        let block_idx = self
-            .alloc_cached()
-            .expect("pool exhausted -- increase block_count in PubSubConfig");
-
-        let topic_idx = handle.topic_idx;
+    pub fn loan(&mut self, handle: &TopicHandle) -> Result<ShmLoan<'_>, IpcError> {
+        let (block_idx, topic_idx) = self.loan_preamble(handle)?;
         let off = topic_entry_off(topic_idx);
-
-        let base_ptr = self.region.base;
-
+        let base_ptr = self.region.base_ptr();
         let write_seq_atom = unsafe { &*(base_ptr.add(off + TE_WRITE_SEQ) as *const AtomicU64) };
-
         let waiters_atom = unsafe { &*(base_ptr.add(off + TE_WAITERS) as *const AtomicU32) };
-
         let data_ptr = unsafe { self.region.block_ptr(block_idx).add(BLOCK_DATA_OFFSET) };
 
-        ShmLoan {
+        Ok(ShmLoan {
             region: &self.region,
             data_ptr,
             capacity: self.region.data_capacity(),
@@ -638,7 +720,7 @@ impl ShmPublisher {
             write_seq_atom,
             waiters_atom,
             single_publisher: self.is_owner,
-        }
+        })
     }
 
     /// Loans a typed block from the pool for writing a `T: Pod` value.
@@ -647,40 +729,21 @@ impl ShmPublisher {
     /// or [`TypedShmLoan::as_mut`] + [`TypedShmLoan::publish`] to
     /// fill fields individually (born-in-SHM pattern).
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the pool is exhausted or the handle belongs to a different
-    /// publisher.
+    /// Returns [`IpcError::PoolExhausted`] if all blocks are in use.
     #[inline]
-    pub fn loan_typed<T: crate::Pod>(&mut self, handle: &TopicHandle) -> TypedShmLoan<'_, T> {
-        debug_assert_eq!(
-            handle.publisher_id, self.id,
-            "TopicHandle belongs to a different ShmPublisher"
-        );
-
-        // Counter-based heartbeat: check clock every 1024 loans, not every loan.
-        self.loan_count = self.loan_count.wrapping_add(1);
-        if self.loan_count & 0x3FF == 0
-            && self.last_heartbeat.elapsed() >= self.region.config.heartbeat_interval
-        {
-            self.region.update_heartbeat();
-            self.last_heartbeat = std::time::Instant::now();
-        }
-
-        let block_idx = self
-            .alloc_cached()
-            .expect("pool exhausted -- increase block_count in PubSubConfig");
-
-        let topic_idx = handle.topic_idx;
+    pub fn loan_typed<T: crate::Pod>(
+        &mut self,
+        handle: &TopicHandle,
+    ) -> Result<TypedShmLoan<'_, T>, IpcError> {
+        let (block_idx, topic_idx) = self.loan_preamble(handle)?;
         let off = topic_entry_off(topic_idx);
-
-        let base_ptr = self.region.base;
-
+        let base_ptr = self.region.base_ptr();
         let write_seq_atom = unsafe { &*(base_ptr.add(off + TE_WRITE_SEQ) as *const AtomicU64) };
-
         let waiters_atom = unsafe { &*(base_ptr.add(off + TE_WAITERS) as *const AtomicU32) };
 
-        TypedShmLoan {
+        Ok(TypedShmLoan {
             region: &self.region,
             block_idx,
             topic_idx,
@@ -688,55 +751,71 @@ impl ShmPublisher {
             waiters_atom,
             single_publisher: self.is_owner,
             _marker: core::marker::PhantomData,
-        }
+        })
     }
 
     /// Loans the pinned block for a topic. On the first call, allocates a
-    /// dedicated block. Subsequent calls return the same block — no alloc.
+    /// dedicated block. Subsequent calls return the same block -- no alloc.
     ///
-    /// The publisher checks the shared reader count before returning the
-    /// loan. If any subscriber holds a [`PinnedGuard`] for this topic,
-    /// this method panics — preventing data races at runtime.
+    /// The publisher uses a CAS-based writer sentinel to prevent data races:
+    /// if any subscriber holds a [`PinnedGuard`] for this topic, this method
+    /// returns an error.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// - If a subscriber holds a `PinnedGuard` for this topic (data race prevention).
-    /// - If the pool is exhausted (first call only).
-    pub fn loan_pinned(&mut self, handle: &TopicHandle) -> PinnedLoan<'_> {
-        debug_assert_eq!(handle.publisher_id, self.id);
+    /// - [`IpcError::PinnedReadersActive`] if a subscriber holds a `PinnedGuard`.
+    /// - [`IpcError::PoolExhausted`] if the pool is exhausted (first call only).
+    pub fn loan_pinned(&mut self, handle: &TopicHandle) -> Result<PinnedLoan<'_>, IpcError> {
+        if handle.publisher_id != self.id {
+            return Err(IpcError::InvalidRegion(
+                "TopicHandle belongs to a different ShmPublisher".into(),
+            ));
+        }
         let topic_idx = handle.topic_idx;
+
+        // Bounds check (H2: pinned_blocks is now Vec sized to max_topics)
+        if topic_idx as usize >= self.pinned_blocks.len() {
+            return Err(IpcError::InvalidRegion(format!(
+                "topic_idx {} >= max_topics {}",
+                topic_idx,
+                self.pinned_blocks.len()
+            )));
+        }
 
         // Get or allocate the pinned block for this topic
         let block_idx = if self.pinned_blocks[topic_idx as usize] != NO_BLOCK {
             self.pinned_blocks[topic_idx as usize]
         } else {
-            let idx = self
-                .alloc_cached()
-                .expect("pool exhausted — increase block_count");
+            let idx = self.alloc_cached().ok_or(IpcError::PoolExhausted)?;
             self.pinned_blocks[topic_idx as usize] = idx;
             // Store in SHM topic entry so subscribers can find it
             self.region.set_pinned_block(topic_idx, idx);
             idx
         };
 
-        let off = topic_entry_off(topic_idx);
-        let base_ptr = self.region.base;
+        // CAS-based writer sentinel: atomically swap readers from 0 to
+        // PINNED_WRITER_ACTIVE. If CAS fails, a subscriber is active.
+        let readers = self.region.pinned_readers(topic_idx);
+        match readers.compare_exchange(0, PINNED_WRITER_ACTIVE, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => {} // Successfully claimed — no readers, sentinel is set
+            Err(current) => {
+                let count = if current == PINNED_WRITER_ACTIVE {
+                    0 // Another writer — shouldn't happen with &mut self, but handle it
+                } else {
+                    current
+                };
+                return Err(IpcError::PinnedReadersActive { count, topic_idx });
+            }
+        }
 
-        // Check reader count — panic if any subscriber holds a PinnedGuard
-        let readers = unsafe { &*(base_ptr.add(off + TE_PINNED_READERS) as *const AtomicU32) };
-        let active = readers.load(Ordering::Acquire);
-        assert!(
-            active == 0,
-            "loan_pinned: {} active PinnedGuard(s) on topic {topic_idx} — \
-             drop all guards before calling loan_pinned",
-            active
-        );
-
-        let write_seq_atom = unsafe { &*(base_ptr.add(off + TE_WRITE_SEQ) as *const AtomicU64) };
-        let waiters_atom = unsafe { &*(base_ptr.add(off + TE_WAITERS) as *const AtomicU32) };
+        let pinned_off = topic_entry_off(topic_idx);
+        let bp = self.region.base_ptr();
+        let write_seq_atom = unsafe { &*(bp.add(pinned_off + TE_WRITE_SEQ) as *const AtomicU64) };
+        let waiters_atom = unsafe { &*(bp.add(pinned_off + TE_WAITERS) as *const AtomicU32) };
         let data_ptr = unsafe { self.region.block_ptr(block_idx).add(BLOCK_DATA_OFFSET) };
 
-        PinnedLoan {
+        Ok(PinnedLoan {
             region: &self.region,
             data_ptr,
             capacity: self.region.data_capacity(),
@@ -744,7 +823,8 @@ impl ShmPublisher {
             topic_idx,
             write_seq_atom,
             waiters_atom,
-        }
+            readers,
+        })
     }
 }
 
@@ -766,8 +846,14 @@ impl Drop for ShmPublisher {
         }
         self.cache_len = 0;
 
-        if self.is_owner && file_identity(&self.path) == self.created_ino {
-            let _ = std::fs::remove_file(&self.path);
+        // Only delete the SHM file if we're the owner and the file identity matches.
+        // Uses Option to prevent deletion on filesystem errors (M15).
+        if self.is_owner {
+            if let (Some(created), Some(current)) = (self.created_ino, file_identity(&self.path)) {
+                if created == current {
+                    let _ = std::fs::remove_file(&self.path);
+                }
+            }
         }
     }
 }
@@ -804,66 +890,9 @@ impl ShmSubscriber {
     /// Returns an error if the region file doesn't exist, has invalid
     /// magic/version, or the publisher's heartbeat is stale.
     pub fn connect(name: &str) -> Result<Self, IpcError> {
-        let path = shm_path(name);
+        validate_name(name)?;
 
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true) // needed for atomic CAS on refcounts
-            .open(&path)
-            .map_err(IpcError::Io)?;
-
-        let mmap = RawMmap::from_file(&file).map_err(IpcError::Io)?;
-
-        if mmap.len() < HEADER_SIZE {
-            return Err(IpcError::InvalidRegion(
-                "region too small for header".into(),
-            ));
-        }
-
-        // Validate header
-        let ptr = mmap.as_ptr();
-        unsafe {
-            let mut magic = [0u8; 8];
-            core::ptr::copy_nonoverlapping(ptr.add(GH_MAGIC), magic.as_mut_ptr(), 8);
-            if &magic != MAGIC {
-                return Err(IpcError::InvalidRegion(
-                    "invalid magic (expected XBAR_ZC)".into(),
-                ));
-            }
-            let ver = (ptr.add(GH_VERSION) as *const u32).read();
-            if ver != VERSION {
-                return Err(IpcError::InvalidRegion(format!(
-                    "unsupported version {ver}, expected {VERSION}"
-                )));
-            }
-        }
-
-        // Read config from header
-        let config = unsafe {
-            PubSubConfig {
-                max_topics: (ptr.add(GH_MAX_TOPICS) as *const u32).read(),
-                block_count: (ptr.add(GH_BLOCK_COUNT) as *const u32).read(),
-                block_size: (ptr.add(GH_BLOCK_SIZE) as *const u32).read(),
-                ring_depth: (ptr.add(GH_RING_DEPTH) as *const u32).read(),
-                stale_timeout: Duration::from_micros(
-                    (ptr.add(GH_STALE_TIMEOUT_US) as *const u64).read(),
-                ),
-                ..PubSubConfig::default()
-            }
-        };
-
-        let expected_size = region_size(&config);
-        if mmap.len() < expected_size {
-            return Err(IpcError::InvalidRegion(format!(
-                "region size {} < expected {expected_size}",
-                mmap.len()
-            )));
-        }
-
-        // SAFETY: mmap provides a valid region of the computed size.
-        let region = Arc::new(unsafe { Region::from_raw(mmap.as_mut_ptr(), mmap.len(), config) });
-
-        region.check_heartbeat()?;
+        let (mmap, region, _path) = open_and_validate_region(name, true)?;
 
         Ok(ShmSubscriber {
             _mmap: mmap,
@@ -879,12 +908,12 @@ impl ShmSubscriber {
     pub fn subscribe(&self, uri: &str) -> Result<Subscription, IpcError> {
         let hash = uri_hash(uri);
 
-        let base_ptr = self.region.base;
+        let base_ptr = self.region.base_ptr();
 
         for i in 0..self.region.config.max_topics {
             let off = topic_entry_off(i);
             let active = unsafe { &*(base_ptr.add(off + TE_ACTIVE) as *const AtomicU32) };
-            if active.load(Ordering::Acquire) != 1 {
+            if active.load(Ordering::Acquire) != TE_STATE_ACTIVE {
                 continue;
             }
             let stored_hash = unsafe { (base_ptr.add(off + TE_URI_HASH) as *const u64).read() };

--- a/src/platform/subscription.rs
+++ b/src/platform/subscription.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use crate::error::IpcError;
 use crate::protocol::layout::*;
-use crate::protocol::Region;
+use crate::protocol::{release_block, Region};
 use crate::wait::WaitStrategy;
 
 use super::notify;
@@ -34,15 +34,25 @@ pub struct Subscription {
     pub(crate) type_size: u32,
 }
 
+impl core::fmt::Debug for Subscription {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Subscription")
+            .field("topic_idx", &self.topic_idx)
+            .field("type_size", &self.type_size)
+            .field("last_seq", &self.last_seq.get())
+            .finish()
+    }
+}
+
 impl Subscription {
     fn write_seq_atom(&self) -> &AtomicU64 {
         let off = topic_entry_off(self.topic_idx);
-        unsafe { &*(self.region.base.add(off + TE_WRITE_SEQ) as *const AtomicU64) }
+        unsafe { &*(self.region.base_ptr().add(off + TE_WRITE_SEQ) as *const AtomicU64) }
     }
 
     fn waiters_atom(&self) -> &AtomicU32 {
         let off = topic_entry_off(self.topic_idx);
-        unsafe { &*(self.region.base.add(off + TE_WAITERS) as *const AtomicU32) }
+        unsafe { &*(self.region.base_ptr().add(off + TE_WAITERS) as *const AtomicU32) }
     }
 
     /// Non-blocking: returns the next sample guard or `None`.
@@ -87,7 +97,7 @@ impl Subscription {
         let ring_mask = self.region.config.ring_depth as u64 - 1;
         let slot = (seq & ring_mask) as u32;
         let entry_off = ring_entry_off(&self.region.config, self.topic_idx, slot);
-        let entry_ptr = unsafe { self.region.base.add(entry_off) };
+        let entry_ptr = unsafe { self.region.base_ptr().add(entry_off) };
 
         #[cfg(target_arch = "x86_64")]
         unsafe {
@@ -120,13 +130,19 @@ impl Subscription {
             return None;
         }
 
-        // Bounds check
+        // C1: Runtime bounds check on block_idx (defense against malicious SHM)
+        if (block_idx as usize) >= self.region.config.block_count as usize {
+            return None;
+        }
+
+        // Bounds check on data_len
         if data_len as usize > self.region.data_capacity() {
             return None;
         }
 
         // CAS increment refcount -- acquire a reference to the block
-        let refcount = self.region.block_refcount(block_idx);
+        // Use block_refcount_checked for extra safety
+        let refcount = self.region.block_refcount_checked(block_idx)?;
         loop {
             let rc = refcount.load(Ordering::Acquire);
             if rc == 0 {
@@ -143,11 +159,7 @@ impl Subscription {
         // Seqlock check 2 -- verify ring slot wasn't overwritten during our read
         if entry_seq.load(Ordering::Acquire) != seq {
             // Undo refcount increment
-            let prev = refcount.fetch_sub(1, Ordering::Release);
-            if prev == 1 {
-                core::sync::atomic::fence(Ordering::Acquire);
-                self.region.free_block(block_idx);
-            }
+            release_block(&self.region, block_idx);
             return None;
         }
 
@@ -175,19 +187,11 @@ impl Subscription {
     /// Uses the same ring-window scan as [`try_recv`](Self::try_recv) to
     /// handle multi-publisher scenarios.
     ///
-    /// # Panics
-    ///
-    /// Panics if the topic was registered with a non-zero type size that
-    /// doesn't match `size_of::<T>()`.
+    /// Returns `None` if no new data is available or if the topic's
+    /// registered type size doesn't match `size_of::<T>()`.
     pub fn try_recv_typed<T: crate::Pod>(&self) -> Option<TypedSampleGuard<'_, T>> {
-        if self.type_size != 0 {
-            assert_eq!(
-                self.type_size as usize,
-                core::mem::size_of::<T>(),
-                "type size mismatch: topic has {} bytes, expected {}",
-                self.type_size,
-                core::mem::size_of::<T>()
-            );
+        if self.type_size != 0 && self.type_size as usize != core::mem::size_of::<T>() {
+            return None; // Type size mismatch — return None instead of panicking
         }
 
         let current_seq = self.write_seq_atom().load(Ordering::Acquire);
@@ -239,54 +243,7 @@ impl Subscription {
         &self,
         strategy: crate::WaitStrategy,
     ) -> Result<TypedSampleGuard<'_, T>, crate::error::IpcError> {
-        // Fast path
-        if let Some(g) = self.try_recv_typed::<T>() {
-            return Ok(g);
-        }
-
-        let poll_ms = (self.region.config.stale_timeout.as_millis() as u64 / 3).clamp(1, 50);
-        let mut iter: u32 = 0;
-
-        loop {
-            if let Some(g) = self.try_recv_typed::<T>() {
-                return Ok(g);
-            }
-
-            match strategy {
-                WaitStrategy::Adaptive {
-                    spin_iters,
-                    yield_iters,
-                } if iter >= spin_iters + yield_iters => {
-                    let seq_futex = unsafe {
-                        &*(self.write_seq_atom() as *const AtomicU64 as *const AtomicU32)
-                    };
-                    let cur = seq_futex.load(Ordering::Acquire);
-                    if let Some(g) = self.try_recv_typed::<T>() {
-                        return Ok(g);
-                    }
-                    self.waiters_atom().fetch_add(1, Ordering::Release);
-                    let result = notify::wait_until_not(
-                        seq_futex,
-                        cur,
-                        Duration::from_millis(poll_ms),
-                        true,
-                    );
-                    self.waiters_atom().fetch_sub(1, Ordering::Release);
-
-                    if result.is_err() {
-                        self.region.check_heartbeat()?;
-                    }
-                }
-                _ => {
-                    strategy.wait(iter);
-                    iter = iter.saturating_add(1);
-
-                    if iter.is_multiple_of(1024) {
-                        self.region.check_heartbeat()?;
-                    }
-                }
-            }
-        }
+        self.blocking_recv(strategy, || self.try_recv_typed::<T>())
     }
 
     /// Blocking: waits for the next sample using the given [`WaitStrategy`].
@@ -301,57 +258,7 @@ impl Subscription {
     ///
     /// Returns [`IpcError::PublisherDead`] if the publisher heartbeat goes stale.
     pub fn recv_with(&self, strategy: WaitStrategy) -> Result<SampleGuard<'_>, IpcError> {
-        // Fast path: check immediately
-        if let Some(g) = self.try_recv() {
-            return Ok(g);
-        }
-
-        let poll_ms = (self.region.config.stale_timeout.as_millis() as u64 / 3).clamp(1, 50);
-        let mut iter: u32 = 0;
-
-        loop {
-            if let Some(g) = self.try_recv() {
-                return Ok(g);
-            }
-
-            match strategy {
-                WaitStrategy::Adaptive {
-                    spin_iters,
-                    yield_iters,
-                } if iter >= spin_iters + yield_iters => {
-                    // Phase 3: OS sleep — use low-32 of write_seq as futex word
-                    let seq_futex = unsafe {
-                        &*(self.write_seq_atom() as *const AtomicU64 as *const AtomicU32)
-                    };
-                    let cur = seq_futex.load(Ordering::Acquire);
-                    if let Some(g) = self.try_recv() {
-                        return Ok(g);
-                    }
-                    self.waiters_atom().fetch_add(1, Ordering::Release);
-                    let result = notify::wait_until_not(
-                        seq_futex,
-                        cur,
-                        Duration::from_millis(poll_ms),
-                        true,
-                    );
-                    self.waiters_atom().fetch_sub(1, Ordering::Release);
-
-                    // Check heartbeat on timeout
-                    if result.is_err() {
-                        self.region.check_heartbeat()?;
-                    }
-                }
-                _ => {
-                    strategy.wait(iter);
-                    iter = iter.saturating_add(1);
-
-                    // Periodic heartbeat check for non-OS-sleep strategies
-                    if iter.is_multiple_of(1024) {
-                        self.region.check_heartbeat()?;
-                    }
-                }
-            }
-        }
+        self.blocking_recv(strategy, || self.try_recv())
     }
 
     /// Blocking: waits for the next sample using the default [`WaitStrategy`]
@@ -365,22 +272,18 @@ impl Subscription {
     }
 
     /// Non-blocking pinned receive. Returns a zero-overhead guard pointing
-    /// directly into the pinned block. No refcount, no seqlock double-check.
-    ///
-    /// Non-blocking pinned receive. Returns a zero-overhead guard pointing
     /// directly into the pinned block.
     ///
     /// The guard increments a shared reader count on creation and decrements
-    /// on drop. The publisher checks this count before writing — if any
-    /// readers exist, `loan_pinned` panics instead of causing UB.
+    /// on drop. The publisher checks this count before writing -- if any
+    /// readers exist, `loan_pinned` returns an error instead of causing UB.
     ///
     /// Returns `None` if no new data has been published since the last recv.
     pub fn try_recv_pinned(&self) -> Option<PinnedGuard<'_>> {
-        let off = topic_entry_off(self.topic_idx);
-
         // Load the pinned seqlock: packed (seq:32 | data_len:32)
+        let off = topic_entry_off(self.topic_idx);
         let pinned_seq =
-            unsafe { &*(self.region.base.add(off + TE_PINNED_SEQ) as *const AtomicU64) };
+            unsafe { &*(self.region.base_ptr().add(off + TE_PINNED_SEQ) as *const AtomicU64) };
         let packed = pinned_seq.load(Ordering::Acquire);
 
         if packed == 0 {
@@ -394,19 +297,49 @@ impl Subscription {
         if seq <= self.last_seq.get() {
             return None; // No new data
         }
-        self.last_seq.set(seq);
 
-        // Read pinned block index from topic entry
-        let block_idx =
-            unsafe { (self.region.base.add(off + TE_PINNED_BLOCK) as *const u32).read() };
+        // Read pinned block index atomically (SHM-R1 fix: use atomic load)
+        let block_idx = self.region.pinned_block(self.topic_idx);
         if block_idx == NO_BLOCK {
             return None;
         }
 
-        // Increment reader count — publisher will check this before writing
-        let readers =
-            unsafe { &*(self.region.base.add(off + TE_PINNED_READERS) as *const AtomicU32) };
-        readers.fetch_add(1, Ordering::Release);
+        // C1: Bounds check on block_idx from SHM
+        if (block_idx as usize) >= self.region.config.block_count as usize {
+            return None;
+        }
+
+        // CAS-based reader registration: only enter if no writer sentinel is set.
+        // PINNED_WRITER_ACTIVE means the publisher is writing — do not enter.
+        let readers = self.region.pinned_readers(self.topic_idx);
+        loop {
+            let current = readers.load(Ordering::Acquire);
+            if current == PINNED_WRITER_ACTIVE {
+                return None; // Publisher is writing — cannot read
+            }
+            // CAS: increment reader count, failing if writer entered between load and CAS
+            match readers.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(_) => continue, // Retry — another subscriber or writer raced us
+            }
+        }
+
+        // Seqlock re-check: verify the data hasn't changed since we read packed.
+        // If the publisher wrote new data between our packed load and reader
+        // increment, our data_len/seq are stale.
+        let packed2 = pinned_seq.load(Ordering::Acquire);
+        if packed2 != packed {
+            // Data changed — undo reader increment and return None
+            readers.fetch_sub(1, Ordering::AcqRel);
+            return None;
+        }
+
+        self.last_seq.set(seq);
 
         let data_ptr = unsafe { self.region.block_ptr(block_idx).add(BLOCK_DATA_OFFSET) };
 
@@ -434,8 +367,18 @@ impl Subscription {
     ///
     /// Returns [`IpcError::PublisherDead`] if the publisher heartbeat goes stale.
     pub fn recv_pinned_with(&self, strategy: WaitStrategy) -> Result<PinnedGuard<'_>, IpcError> {
-        // Fast path
-        if let Some(g) = self.try_recv_pinned() {
+        self.blocking_recv(strategy, || self.try_recv_pinned())
+    }
+
+    /// Generic blocking receive loop shared by all blocking recv variants (M1).
+    /// Eliminates the copy-paste between recv_with, recv_typed_with, and recv_pinned_with.
+    fn blocking_recv<T>(
+        &self,
+        strategy: WaitStrategy,
+        try_fn: impl Fn() -> Option<T>,
+    ) -> Result<T, IpcError> {
+        // Fast path: check immediately
+        if let Some(g) = try_fn() {
             return Ok(g);
         }
 
@@ -443,7 +386,7 @@ impl Subscription {
         let mut iter: u32 = 0;
 
         loop {
-            if let Some(g) = self.try_recv_pinned() {
+            if let Some(g) = try_fn() {
                 return Ok(g);
             }
 
@@ -451,12 +394,13 @@ impl Subscription {
                 WaitStrategy::Adaptive {
                     spin_iters,
                     yield_iters,
-                } if iter >= spin_iters + yield_iters => {
+                } if iter >= spin_iters.saturating_add(yield_iters) => {
+                    // Phase 3: OS sleep -- use low-32 of write_seq as futex word
                     let seq_futex = unsafe {
                         &*(self.write_seq_atom() as *const AtomicU64 as *const AtomicU32)
                     };
                     let cur = seq_futex.load(Ordering::Acquire);
-                    if let Some(g) = self.try_recv_pinned() {
+                    if let Some(g) = try_fn() {
                         return Ok(g);
                     }
                     self.waiters_atom().fetch_add(1, Ordering::Release);
@@ -468,6 +412,7 @@ impl Subscription {
                     );
                     self.waiters_atom().fetch_sub(1, Ordering::Release);
 
+                    // Check heartbeat on timeout
                     if result.is_err() {
                         self.region.check_heartbeat()?;
                     }
@@ -476,6 +421,7 @@ impl Subscription {
                     strategy.wait(iter);
                     iter = iter.saturating_add(1);
 
+                    // Periodic heartbeat check for non-OS-sleep strategies
                     if iter.is_multiple_of(1024) {
                         self.region.check_heartbeat()?;
                     }
@@ -555,7 +501,6 @@ impl AsRef<[u8]> for SampleGuard<'_> {
 impl core::fmt::Debug for SampleGuard<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("SampleGuard")
-            .field("block_idx", &self.block_idx)
             .field("len", &self.len)
             .finish()
     }
@@ -563,12 +508,7 @@ impl core::fmt::Debug for SampleGuard<'_> {
 
 impl Drop for SampleGuard<'_> {
     fn drop(&mut self) {
-        let refcount = self.region.block_refcount(self.block_idx);
-        let prev = refcount.fetch_sub(1, Ordering::Release);
-        if prev == 1 {
-            core::sync::atomic::fence(Ordering::Acquire);
-            self.region.free_block(self.block_idx);
-        }
+        release_block(self.region, self.block_idx);
     }
 }
 
@@ -597,19 +537,13 @@ impl<T: crate::Pod> core::ops::Deref for TypedSampleGuard<'_, T> {
 
 impl<T: crate::Pod> Drop for TypedSampleGuard<'_, T> {
     fn drop(&mut self) {
-        let refcount = self.region.block_refcount(self.block_idx);
-        let prev = refcount.fetch_sub(1, Ordering::Release);
-        if prev == 1 {
-            core::sync::atomic::fence(Ordering::Acquire);
-            self.region.free_block(self.block_idx);
-        }
+        release_block(self.region, self.block_idx);
     }
 }
 
 impl<T: crate::Pod> core::fmt::Debug for TypedSampleGuard<'_, T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("TypedSampleGuard")
-            .field("block_idx", &self.block_idx)
             .field("size", &core::mem::size_of::<T>())
             .finish()
     }
@@ -621,8 +555,8 @@ impl<T: crate::Pod> core::fmt::Debug for TypedSampleGuard<'_, T> {
 ///
 /// On creation, increments a shared reader count in the topic entry.
 /// On drop, decrements it. The publisher checks this count before writing
-/// and panics if any readers exist — preventing data races at runtime
-/// without requiring `unsafe`.
+/// and returns an error if any readers exist -- preventing data races at
+/// runtime without requiring `unsafe`.
 pub struct PinnedGuard<'a> {
     data_ptr: *const u8,
     len: usize,
@@ -656,7 +590,7 @@ impl AsRef<[u8]> for PinnedGuard<'_> {
 
 impl Drop for PinnedGuard<'_> {
     fn drop(&mut self) {
-        self.readers.fetch_sub(1, Ordering::Release);
+        self.readers.fetch_sub(1, Ordering::AcqRel);
     }
 }
 

--- a/src/protocol/layout.rs
+++ b/src/protocol/layout.rs
@@ -8,6 +8,12 @@
 //!
 //! All functions are pure computation -- no OS calls.
 
+// Crossbar uses futex on the low-32 of AtomicU64, which only works on
+// little-endian. All supported platforms (x86-64, aarch64 in default mode)
+// are little-endian.
+#[cfg(not(target_endian = "little"))]
+compile_error!("crossbar requires a little-endian target");
+
 use super::config::PubSubConfig;
 
 pub(crate) const MAGIC: &[u8; 8] = b"XBAR_ZC\0";
@@ -27,6 +33,14 @@ pub(crate) const SEQ_WRITING: u64 = u64::MAX;
 pub(crate) const TE_STATE_FREE: u32 = 0;
 pub(crate) const TE_STATE_INIT: u32 = 2;
 pub(crate) const TE_STATE_ACTIVE: u32 = 1;
+
+/// Maximum allowed `max_topics` to prevent OOM from malicious headers.
+pub(crate) const MAX_TOPICS_LIMIT: u32 = 4096;
+
+/// Writer-active sentinel for pinned publish. Stored in TE_PINNED_READERS
+/// via CAS to atomically prevent subscribers from entering while the
+/// publisher is writing. Must not collide with valid reader counts.
+pub(crate) const PINNED_WRITER_ACTIVE: u32 = u32::MAX;
 
 // Global header offsets
 pub(crate) const GH_MAGIC: usize = 0;
@@ -53,7 +67,7 @@ pub(crate) const TE_TYPE_SIZE: usize = 0x60; // u32 -- size_of::<T>() for typed 
 /// Pinned-publish block index (u32). NO_BLOCK = not pinned.
 /// Located in topic entry cache line 1 (cold path, set once at registration).
 pub(crate) const TE_PINNED_BLOCK: usize = 0x64;
-/// Pinned-publish active reader count (AtomicU32). Publisher panics if > 0
+/// Pinned-publish active reader count (AtomicU32). Publisher returns error if > 0
 /// when loan_pinned is called. Enables safe pinned API without `unsafe`.
 pub(crate) const TE_PINNED_READERS: usize = 0x68; // AtomicU32
 /// Pinned-publish seqlock: packed (seq:32 | data_len:32) in AtomicU64.
@@ -89,12 +103,25 @@ pub(crate) fn ring_entry_off(config: &PubSubConfig, topic_idx: u32, slot: u32) -
         + slot as usize * RING_ENTRY_SIZE
 }
 
+/// Compute block pool offset with checked arithmetic. Returns `None` on overflow.
+pub(crate) fn block_pool_offset_checked(config: &PubSubConfig) -> Option<usize> {
+    let rb = ring_base(config);
+    let ring_size = (config.max_topics as usize)
+        .checked_mul(config.ring_depth as usize)?
+        .checked_mul(RING_ENTRY_SIZE)?;
+    rb.checked_add(ring_size)
+}
+
 pub(crate) fn block_pool_offset(config: &PubSubConfig) -> usize {
+    // Only called after config is validated and region_size_checked passed.
     ring_base(config) + config.max_topics as usize * config.ring_depth as usize * RING_ENTRY_SIZE
 }
 
-pub(crate) fn region_size(config: &PubSubConfig) -> usize {
-    block_pool_offset(config) + config.block_count as usize * config.block_size as usize
+/// Compute the total region size with fully checked arithmetic. Returns `None` on overflow.
+pub(crate) fn region_size_checked(config: &PubSubConfig) -> Option<usize> {
+    let pool_off = block_pool_offset_checked(config)?;
+    let pool_size = (config.block_count as usize).checked_mul(config.block_size as usize)?;
+    pool_off.checked_add(pool_size)
 }
 
 pub(crate) fn uri_hash(uri: &str) -> u64 {
@@ -117,4 +144,14 @@ pub(crate) fn pack(gen: u32, idx: u32) -> u64 {
 #[allow(clippy::cast_possible_truncation)]
 pub(crate) fn unpack(val: u64) -> (u32, u32) {
     ((val >> 32) as u32, val as u32)
+}
+
+/// Validate that a segment name contains no path traversal characters.
+/// Returns `true` if the name is safe.
+pub(crate) fn is_valid_segment_name(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    // Reject path separators, parent-dir references, and null bytes
+    !name.contains('/') && !name.contains('\\') && !name.contains('\0') && !name.contains("..")
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -14,4 +14,5 @@ pub(crate) mod layout;
 mod region;
 
 pub use config::PubSubConfig;
+pub(crate) use region::release_block;
 pub use region::Region;

--- a/src/protocol/region.rs
+++ b/src/protocol/region.rs
@@ -20,9 +20,7 @@ use crate::platform::notify;
 /// Shared state for the mmap region -- held by both publisher/subscriber
 /// and by `SampleGuard` (via `Arc`) to keep the mmap alive.
 pub struct Region {
-    pub(crate) base: *mut u8,
-    #[allow(dead_code)]
-    pub(crate) len: usize,
+    base: *mut u8,
     pub(crate) config: PubSubConfig,
     pub(crate) pool_offset: usize,
     pub(crate) last_freed: AtomicU32,
@@ -41,15 +39,20 @@ impl Region {
     ///
     /// `base` must point to a valid, mmap'd region of at least `len` bytes
     /// that remains valid for the lifetime of this Region.
-    pub unsafe fn from_raw(base: *mut u8, len: usize, config: PubSubConfig) -> Self {
+    pub(crate) unsafe fn from_raw(base: *mut u8, _len: usize, config: PubSubConfig) -> Self {
         let pool_offset = block_pool_offset(&config);
         Self {
             base,
-            len,
             config,
             pool_offset,
             last_freed: AtomicU32::new(NO_BLOCK),
         }
+    }
+
+    /// Returns the raw base pointer to the mmap region.
+    #[inline]
+    pub(crate) fn base_ptr(&self) -> *mut u8 {
+        self.base
     }
 
     #[inline]
@@ -57,6 +60,23 @@ impl Region {
         unsafe { &*(self.base.add(GH_POOL_HEAD) as *const AtomicU64) }
     }
 
+    /// Returns a pointer to the block at `idx`, or `None` if out of bounds.
+    #[inline]
+    pub(crate) fn block_ptr_checked(&self, idx: u32) -> Option<*mut u8> {
+        if (idx as usize) >= self.config.block_count as usize {
+            return None;
+        }
+        Some(unsafe {
+            self.base
+                .add(self.pool_offset + idx as usize * self.config.block_size as usize)
+        })
+    }
+
+    /// Returns a pointer to the block at `idx`.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug mode if `idx >= block_count`.
     #[inline]
     pub(crate) fn block_ptr(&self, idx: u32) -> *mut u8 {
         debug_assert!((idx as usize) < self.config.block_count as usize);
@@ -64,6 +84,14 @@ impl Region {
             self.base
                 .add(self.pool_offset + idx as usize * self.config.block_size as usize)
         }
+    }
+
+    /// Returns the refcount atomic for block `idx`, with bounds check.
+    /// Returns `None` if `idx >= block_count`.
+    #[inline]
+    pub(crate) fn block_refcount_checked(&self, idx: u32) -> Option<&AtomicU32> {
+        let ptr = self.block_ptr_checked(idx)?;
+        Some(unsafe { &*(ptr.add(BK_REFCOUNT) as *const AtomicU32) })
     }
 
     #[inline]
@@ -79,8 +107,18 @@ impl Region {
             if idx == NO_BLOCK {
                 return None;
             }
+            // Validate idx is within bounds (H6: free-list corruption defense)
+            if (idx as usize) >= self.config.block_count as usize {
+                return None;
+            }
             let block = self.block_ptr(idx);
             let next = unsafe { &*(block as *const AtomicU32) }.load(Ordering::Relaxed);
+
+            // Validate next pointer too (defense against corrupted free-list)
+            if next != NO_BLOCK && (next as usize) >= self.config.block_count as usize {
+                return None;
+            }
+
             let new_head = pack(gen.wrapping_add(1), next);
 
             // Prefetch the block data into L1 cache before the CAS attempt
@@ -125,7 +163,9 @@ impl Region {
 
     #[inline]
     pub(crate) fn free_block(&self, idx: u32) {
-        debug_assert!((idx as usize) < self.config.block_count as usize);
+        if (idx as usize) >= self.config.block_count as usize {
+            return; // Bounds check: silently ignore corrupt block_idx in Drop paths
+        }
         let mut head = self.pool_head().load(Ordering::Acquire);
         loop {
             let (gen, old_head_idx) = unpack(head);
@@ -165,28 +205,32 @@ impl Region {
         self.config.block_size as usize - BLOCK_DATA_OFFSET
     }
 
-    pub(crate) fn heartbeat_atom(&self) -> &AtomicU64 {
+    fn heartbeat_atom(&self) -> &AtomicU64 {
         unsafe { &*(self.base.add(GH_HEARTBEAT) as *const AtomicU64) }
     }
 
+    /// Returns microseconds since UNIX epoch, or error if clock is behind epoch.
     #[cfg(feature = "std")]
     #[allow(clippy::cast_possible_truncation)]
-    pub(crate) fn update_heartbeat(&self) {
-        let now = std::time::SystemTime::now()
+    fn now_micros() -> Result<u64, crate::error::IpcError> {
+        std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_micros() as u64;
+            .map(|d| d.as_micros() as u64)
+            .map_err(|_| crate::error::IpcError::ClockError)
+    }
+
+    #[cfg(feature = "std")]
+    pub(crate) fn update_heartbeat(&self) -> Result<(), crate::error::IpcError> {
+        let now = Self::now_micros()?;
         self.heartbeat_atom().fetch_max(now, Ordering::Release);
+        Ok(())
     }
 
     #[cfg(feature = "std")]
     #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn check_heartbeat(&self) -> Result<(), crate::error::IpcError> {
         let hb = self.heartbeat_atom().load(Ordering::Acquire);
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_micros() as u64;
+        let now = Self::now_micros()?;
         if now.saturating_sub(hb) > self.config.stale_timeout.as_micros() as u64 {
             return Err(crate::error::IpcError::PublisherDead);
         }
@@ -195,11 +239,6 @@ impl Region {
 
     /// Pinned publish: store (seq, data_len) atomically. The block is permanently
     /// assigned -- no alloc, no free, no refcount. 1 atomic Release store.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure no subscriber holds a `PinnedGuard` for this topic
-    /// while the publisher is writing to the pinned block.
     #[cfg(feature = "std")]
     #[inline]
     pub(crate) fn commit_pinned(
@@ -229,7 +268,24 @@ impl Region {
     #[inline]
     pub(crate) fn set_pinned_block(&self, topic_idx: u32, block_idx: u32) {
         let off = topic_entry_off(topic_idx);
-        unsafe { (self.base.add(off + TE_PINNED_BLOCK) as *mut u32).write(block_idx) }
+        // Use atomic store with Release so subscriber's Acquire load sees the value
+        unsafe { &*(self.base.add(off + TE_PINNED_BLOCK) as *const AtomicU32) }
+            .store(block_idx, Ordering::Release);
+    }
+
+    /// Load pinned block index atomically.
+    #[inline]
+    pub(crate) fn pinned_block(&self, topic_idx: u32) -> u32 {
+        let off = topic_entry_off(topic_idx);
+        unsafe { &*(self.base.add(off + TE_PINNED_BLOCK) as *const AtomicU32) }
+            .load(Ordering::Acquire)
+    }
+
+    /// Returns the pinned readers atomic for a topic.
+    #[inline]
+    pub(crate) fn pinned_readers(&self, topic_idx: u32) -> &AtomicU32 {
+        let off = topic_entry_off(topic_idx);
+        unsafe { &*(self.base.add(off + TE_PINNED_READERS) as *const AtomicU32) }
     }
 
     /// Shared commit logic for both `ShmLoan` and `TypedShmLoan`.
@@ -303,7 +359,8 @@ impl Region {
         entry_seq.store(seq, Ordering::Release);
 
         // 7. Release old block (decrement refcount; recycle if no subscribers hold it)
-        if old_block_idx != NO_BLOCK {
+        if old_block_idx != NO_BLOCK && (old_block_idx as usize) < self.config.block_count as usize
+        {
             let prev = self
                 .block_refcount(old_block_idx)
                 .fetch_sub(1, Ordering::AcqRel);
@@ -323,9 +380,25 @@ impl Region {
         //    already changed the value so waiters will see it and wake up.
         if wake && waiters_atom.load(Ordering::Acquire) > 0 {
             // Safety: AtomicU64 is at least 4-byte aligned. On little-endian
-            // (all supported platforms), the low 32 bits are at the base address.
+            // (enforced by compile_error in layout.rs), the low 32 bits are
+            // at the base address.
             let seq_futex = unsafe { &*(write_seq_atom as *const AtomicU64 as *const AtomicU32) };
             notify::wake_all(seq_futex);
         }
+    }
+}
+
+/// Release a block's refcount. If this is the last reference, free it to the pool.
+/// Shared by `SampleGuard::drop`, `TypedSampleGuard::drop`, and `CrossbarSample::drop`.
+pub(crate) fn release_block(region: &Region, block_idx: u32) {
+    // Runtime bounds check (Codex/Security: must not use debug_assert in Drop paths)
+    let refcount = match region.block_refcount_checked(block_idx) {
+        Some(rc) => rc,
+        None => return, // OOB block_idx — silently ignore in Drop path
+    };
+    let prev = refcount.fetch_sub(1, Ordering::Release);
+    if prev == 1 {
+        core::sync::atomic::fence(Ordering::Acquire);
+        region.free_block(block_idx);
     }
 }

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -118,7 +118,7 @@ impl WaitStrategy {
             } => {
                 if iter < *spin_iters {
                     // Phase 1: bare spin -- fastest wakeup.
-                } else if iter < spin_iters + yield_iters {
+                } else if iter < spin_iters.saturating_add(*yield_iters) {
                     // Phase 2: yield-spin -- yields pipeline.
                     yield_hint();
                 }
@@ -149,25 +149,35 @@ mod tests {
     #[test]
     fn busy_spin_returns_immediately() {
         let ws = WaitStrategy::BusySpin;
+        let start = std::time::Instant::now();
         for i in 0..1000 {
             ws.wait(i);
         }
+        // BusySpin with 1000 iterations should complete in well under 100ms
+        assert!(start.elapsed().as_millis() < 100, "BusySpin took too long");
     }
 
     #[test]
     fn yield_spin_returns() {
         let ws = WaitStrategy::YieldSpin;
+        let start = std::time::Instant::now();
         for i in 0..100 {
             ws.wait(i);
         }
+        assert!(start.elapsed().as_millis() < 500, "YieldSpin took too long");
     }
 
     #[test]
     fn backoff_spin_returns() {
         let ws = WaitStrategy::BackoffSpin;
+        let start = std::time::Instant::now();
         for i in 0..20 {
             ws.wait(i);
         }
+        assert!(
+            start.elapsed().as_millis() < 500,
+            "BackoffSpin took too long"
+        );
     }
 
     #[test]
@@ -176,9 +186,22 @@ mod tests {
             spin_iters: 4,
             yield_iters: 4,
         };
+        let start = std::time::Instant::now();
         for i in 0..20 {
             ws.wait(i);
         }
+        assert!(start.elapsed().as_millis() < 500, "Adaptive took too long");
+    }
+
+    #[test]
+    fn adaptive_saturating_add_no_overflow() {
+        // M7: u32::MAX + 1 should not wrap
+        let ws = WaitStrategy::Adaptive {
+            spin_iters: u32::MAX,
+            yield_iters: 1,
+        };
+        // Should not panic from overflow
+        ws.wait(u32::MAX);
     }
 
     #[test]
@@ -195,6 +218,6 @@ mod tests {
     fn debug_format() {
         let ws = WaitStrategy::BusySpin;
         let s = alloc::format!("{ws:?}");
-        assert!(s.contains("BusySpin"));
+        assert_eq!(s, "BusySpin");
     }
 }

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -16,14 +16,14 @@ fn channel_bidirectional() {
         let msg = srv.recv().unwrap();
         assert_eq!(&*msg, b"ping");
         drop(msg);
-        srv.send(b"pong");
+        srv.send(b"pong").unwrap();
     });
 
     std::thread::sleep(Duration::from_millis(50));
 
     let mut cli =
         ShmChannel::connect(&name, PubSubConfig::default(), Duration::from_secs(5)).unwrap();
-    cli.send(b"ping");
+    cli.send(b"ping").unwrap();
     let reply = cli.recv().unwrap();
     assert_eq!(&*reply, b"pong");
 
@@ -48,9 +48,9 @@ fn channel_loan_pattern() {
 
     let mut cli =
         ShmChannel::connect(&name, PubSubConfig::default(), Duration::from_secs(5)).unwrap();
-    let mut loan = cli.loan();
+    let mut loan = cli.loan().unwrap();
     loan.as_mut_slice()[..8].copy_from_slice(&42u64.to_le_bytes());
-    loan.set_len(8);
+    loan.set_len(8).unwrap();
     loan.publish();
 
     server.join().unwrap();
@@ -69,7 +69,7 @@ fn channel_multiple_messages() {
             let val = u32::from_le_bytes(msg[..4].try_into().unwrap());
             assert_eq!(val, i);
             drop(msg);
-            srv.send(&(i * 10).to_le_bytes());
+            srv.send(&(i * 10).to_le_bytes()).unwrap();
         }
     });
 
@@ -78,7 +78,7 @@ fn channel_multiple_messages() {
     let mut cli =
         ShmChannel::connect(&name, PubSubConfig::default(), Duration::from_secs(5)).unwrap();
     for i in 0u32..10 {
-        cli.send(&i.to_le_bytes());
+        cli.send(&i.to_le_bytes()).unwrap();
         let reply = cli.recv().unwrap();
         let val = u32::from_le_bytes(reply[..4].try_into().unwrap());
         assert_eq!(val, i * 10);

--- a/tests/multi_publisher.rs
+++ b/tests/multi_publisher.rs
@@ -23,12 +23,12 @@ fn multi_publisher_same_topic() {
     let stream = sub.subscribe("/data").unwrap();
 
     // Both publish
-    let mut loan_a = pub_a.loan(&topic_a);
-    loan_a.set_data(b"from_a");
+    let mut loan_a = pub_a.loan(&topic_a).unwrap();
+    loan_a.set_data(b"from_a").unwrap();
     loan_a.publish();
 
-    let mut loan_b = pub_b.loan(&topic_b);
-    loan_b.set_data(b"from_b");
+    let mut loan_b = pub_b.loan(&topic_b).unwrap();
+    loan_b.set_data(b"from_b").unwrap();
     loan_b.publish();
 
     // Subscriber should receive both (order not guaranteed)
@@ -63,12 +63,12 @@ fn multi_publisher_different_topics() {
     let stream_a = sub.subscribe("/prices/AAPL").unwrap();
     let stream_b = sub.subscribe("/prices/GOOG").unwrap();
 
-    let mut loan = pub_a.loan(&topic_a);
-    loan.set_data(b"AAPL");
+    let mut loan = pub_a.loan(&topic_a).unwrap();
+    loan.set_data(b"AAPL").unwrap();
     loan.publish();
 
-    let mut loan = pub_b.loan(&topic_b);
-    loan.set_data(b"GOOG");
+    let mut loan = pub_b.loan(&topic_b).unwrap();
+    loan.set_data(b"GOOG").unwrap();
     loan.publish();
 
     let guard_a = stream_a.try_recv().unwrap();
@@ -97,8 +97,8 @@ fn multi_publisher_owner_cleanup() {
     let sub = ShmSubscriber::connect(&name).unwrap();
     let stream = sub.subscribe("/test").unwrap();
 
-    let mut loan = pub_a.loan(&_topic_a);
-    loan.set_data(b"still alive");
+    let mut loan = pub_a.loan(&_topic_a).unwrap();
+    loan.set_data(b"still alive").unwrap();
     loan.publish();
 
     let guard = stream.try_recv().unwrap();
@@ -117,11 +117,12 @@ fn multi_publisher_heartbeat() {
     let mut pub_b = ShmPublisher::open(&name).unwrap();
     let _topic_b = pub_b.register("/hb").unwrap();
 
-    // Both update heartbeat -- should not panic
-    pub_a.heartbeat();
-    pub_b.heartbeat();
+    // Both update heartbeat -- should not error
+    pub_a.heartbeat().unwrap();
+    pub_b.heartbeat().unwrap();
 
     // Subscriber should still see the region as alive
     let sub = ShmSubscriber::connect(&name).unwrap();
-    let _stream = sub.subscribe("/hb").unwrap();
+    let stream = sub.subscribe("/hb").unwrap();
+    assert!(stream.try_recv().is_none(), "should have no pending data");
 }

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -12,8 +12,8 @@ fn pubsub_basic_publish_subscribe() {
     let stream = sub.subscribe("/test").unwrap();
 
     // Publish a sample
-    let mut loan = pub_.loan(&topic);
-    loan.set_data(b"hello pubsub");
+    let mut loan = pub_.loan(&topic).unwrap();
+    loan.set_data(b"hello pubsub").unwrap();
     loan.publish();
 
     // Receive it
@@ -32,9 +32,9 @@ fn pubsub_safe_deref() {
     let sub = ShmSubscriber::connect(name).unwrap();
     let stream = sub.subscribe("/tick").unwrap();
 
-    let mut loan = pub_.loan(&topic);
+    let mut loan = pub_.loan(&topic).unwrap();
     loan.as_mut_slice()[..8].copy_from_slice(&42u64.to_le_bytes());
-    loan.set_len(8);
+    loan.set_len(8).unwrap();
     loan.publish();
 
     let guard = stream.try_recv().unwrap();
@@ -59,8 +59,8 @@ fn pubsub_guard_survives_ring_overwrite() {
     let stream = sub.subscribe("/data").unwrap();
 
     // Publish first sample
-    let mut loan = pub_.loan(&topic);
-    loan.set_data(b"first");
+    let mut loan = pub_.loan(&topic).unwrap();
+    loan.set_data(b"first").unwrap();
     loan.publish();
 
     // Read and HOLD the guard
@@ -69,8 +69,8 @@ fn pubsub_guard_survives_ring_overwrite() {
 
     // Overwrite the ring 10x (ring_depth=4, so slot 0 is overwritten)
     for i in 0u32..10 {
-        let mut loan = pub_.loan(&topic);
-        loan.set_data(&i.to_le_bytes());
+        let mut loan = pub_.loan(&topic).unwrap();
+        loan.set_data(&i.to_le_bytes()).unwrap();
         loan.publish();
     }
 
@@ -90,12 +90,12 @@ fn pubsub_multiple_topics() {
     let s1 = sub.subscribe("/a").unwrap();
     let s2 = sub.subscribe("/b").unwrap();
 
-    let mut loan = pub_.loan(&t1);
-    loan.set_data(b"alpha");
+    let mut loan = pub_.loan(&t1).unwrap();
+    loan.set_data(b"alpha").unwrap();
     loan.publish();
 
-    let mut loan = pub_.loan(&t2);
-    loan.set_data(b"beta");
+    let mut loan = pub_.loan(&t2).unwrap();
+    loan.set_data(b"beta").unwrap();
     loan.publish();
 
     assert_eq!(&*s1.try_recv().unwrap(), b"alpha");
@@ -117,14 +117,14 @@ fn pubsub_loan_dropped_without_publish() {
 
     // Allocate and drop 20 loans without publishing — if blocks leak, we'd panic
     for _ in 0..20 {
-        let mut loan = pub_.loan(&topic);
-        loan.set_data(b"unused");
+        let mut loan = pub_.loan(&topic).unwrap();
+        loan.set_data(b"unused").unwrap();
         drop(loan); // should free the block
     }
 
     // Still works — blocks were returned to pool
-    let mut loan = pub_.loan(&topic);
-    loan.set_data(b"ok");
+    let mut loan = pub_.loan(&topic).unwrap();
+    loan.set_data(b"ok").unwrap();
     loan.publish();
 }
 
@@ -139,13 +139,13 @@ fn pubsub_born_in_shm_pattern() {
     let stream = sub.subscribe("/sensor").unwrap();
 
     // Write a struct directly into SHM (born-in-SHM)
-    let mut loan = pub_.loan(&topic);
+    let mut loan = pub_.loan(&topic).unwrap();
     let buf = loan.as_mut_slice();
     let ts: u64 = 1234567890;
     let value: f64 = std::f64::consts::PI;
     buf[..8].copy_from_slice(&ts.to_le_bytes());
     buf[8..16].copy_from_slice(&value.to_le_bytes());
-    loan.set_len(16);
+    loan.set_len(16).unwrap();
     loan.publish();
 
     let guard = stream.try_recv().unwrap();
@@ -166,8 +166,8 @@ fn pubsub_sequential_consistency() {
 
     // Publish 100 sequential values
     for i in 0u64..100 {
-        let mut loan = pub_.loan(&topic);
-        loan.set_data(&i.to_le_bytes());
+        let mut loan = pub_.loan(&topic).unwrap();
+        loan.set_data(&i.to_le_bytes()).unwrap();
         loan.publish();
     }
 
@@ -181,4 +181,5 @@ fn pubsub_sequential_consistency() {
         last = Some(val);
     }
     assert!(last.is_some(), "should have received at least one sample");
+    assert_eq!(last, Some(99));
 }

--- a/tests/typed_pubsub.rs
+++ b/tests/typed_pubsub.rs
@@ -23,7 +23,7 @@ fn typed_publish_subscribe() {
         volume: 100,
         _pad: 0,
     };
-    pub_.loan_typed::<Tick>(&handle).send(tick);
+    pub_.loan_typed::<Tick>(&handle).unwrap().send(tick);
 
     let guard = stream.try_recv_typed::<Tick>().unwrap();
     assert_eq!(*guard, tick);
@@ -39,12 +39,16 @@ fn typed_send_multiple() {
     let stream = sub.subscribe("/counter").unwrap();
 
     for i in 0..10u64 {
-        pub_.loan_typed::<u64>(&handle).send(i);
+        pub_.loan_typed::<u64>(&handle).unwrap().send(i);
     }
 
     // Should get the latest (ring depth = 8 by default)
     let guard = stream.try_recv_typed::<u64>().unwrap();
-    assert!(*guard < 10);
+    assert!(
+        *guard >= 2 && *guard <= 9,
+        "expected value in [2,9], got {}",
+        *guard
+    );
 }
 
 #[test]
@@ -56,7 +60,7 @@ fn typed_loan_as_mut() {
     let sub = ShmSubscriber::connect(name).unwrap();
     let stream = sub.subscribe("/tick").unwrap();
 
-    let mut loan = pub_.loan_typed::<Tick>(&handle);
+    let mut loan = pub_.loan_typed::<Tick>(&handle).unwrap();
     let t = loan.as_mut();
     t.price = 99.9;
     t.volume = 500;
@@ -69,15 +73,22 @@ fn typed_loan_as_mut() {
 }
 
 #[test]
-#[should_panic(expected = "type size mismatch")]
-fn typed_size_mismatch_panics() {
+fn typed_size_mismatch_returns_none() {
     let name = &format!("test-typed-mismatch-{}", std::process::id());
     let mut pub_ = ShmPublisher::create(name, PubSubConfig::default()).unwrap();
-    let _handle = pub_.register_typed::<u64>("/data").unwrap();
+    let handle = pub_.register_typed::<u64>("/data").unwrap();
+
+    // Publish a u64 value so there's data available
+    pub_.loan_typed::<u64>(&handle).unwrap().send(42u64);
 
     let sub = ShmSubscriber::connect(name).unwrap();
     let stream = sub.subscribe("/data").unwrap();
-    let _ = stream.try_recv_typed::<u32>(); // panic: 8 != 4
+    // Mismatched type size: topic is u64 (8 bytes), we request u32 (4 bytes)
+    // Should return None instead of panicking
+    assert!(
+        stream.try_recv_typed::<u32>().is_none(),
+        "type mismatch should return None"
+    );
 }
 
 #[test]
@@ -89,8 +100,8 @@ fn untyped_api_still_works() {
     let sub = ShmSubscriber::connect(name).unwrap();
     let stream = sub.subscribe("/raw").unwrap();
 
-    let mut loan = pub_.loan(&handle);
-    loan.set_data(b"hello");
+    let mut loan = pub_.loan(&handle).unwrap();
+    loan.set_data(b"hello").unwrap();
     loan.publish();
 
     let guard = stream.try_recv().unwrap();


### PR DESCRIPTION
## Summary

- Fix pinned publish TOCTOU data race with CAS sentinel protocol (Fixes #13)
- Convert all library panics to Result returns with new IpcError variants (Fixes #14)
- Security hardening: path traversal, file permissions, config validation, FFI null safety (Fixes #15)
- Replace silent error swallowing with proper propagation (Fixes #16)

## Changes (22 files, +919 -642)

### Safety & Correctness
- Pinned publish: CAS `compare_exchange(0, WRITER_ACTIVE)` sentinel — prevents publisher/subscriber data race
- Pinned subscribe: CAS loop rejecting sentinel + seqlock re-check after reader increment
- `PinnedLoan` has `Drop` impl to clear sentinel on panic/early-drop
- `release_block`/`free_block`: runtime bounds checks (not debug_assert)
- `TopicHandle` validation: runtime if-check (not debug_assert_eq)
- `len as u32` truncation: runtime `assert!` (not `debug_assert!`)
- Pinned `block_idx`: atomic load with Acquire (not plain pointer read)

### Error Handling
- `loan()`/`loan_typed()`/`loan_pinned()` → `Result<_, PoolExhausted>`
- `set_data()`/`set_len()` → `Result<_, DataTooLarge>`
- `heartbeat()` → `Result<_, ClockError>`
- `try_recv_typed()` returns `None` on type mismatch (was panic)
- New `IpcError` variants: `PoolExhausted`, `DataTooLarge`, `PinnedReadersActive`, `ClockError`

### Security
- Path traversal defense: reject `/`, `\`, `..`, null bytes in segment names
- File permissions: `mode(0o600)` on Unix
- Config validation in `connect()`/`open()`: power-of-2 ring_depth, bounded fields
- `max_topics` capped at 4096 (prevents OOM from malicious SHM headers)
- FFI: null checks on all 22 `extern "C"` functions
- FFI: `from_raw_parts` null+len=0 UB fixed
- Free-list: bounds check on both `idx` and `next` pointer
- Fully checked arithmetic: `region_size_checked` + `block_pool_offset_checked`
- `compile_error!` on non-little-endian targets

### Code Quality
- Deduplicated: `blocking_recv<T>`, `open_and_validate_region`, `loan_preamble`, `release_block`
- `Region::from_raw` → `pub(crate)`, `Region.base` made private
- Removed `#[allow(dead_code)]` on `Region.len` (field removed)
- `TopicHandle` derives `Clone, Copy, Debug, PartialEq, Eq`
- Magic number `1` → `TE_STATE_ACTIVE` constant

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo clippy --features ffi -- -D warnings` — clean
- [x] `cargo test --workspace` — 27 tests + 5 doc-tests pass
- [x] Multi-model audit: 4 models (Claude, Codex, Gemini, Kimi) — all APPROVE
- [x] 10-agent independent audit: 8 APPROVE, 1 FIXED, 1 test coverage (not code bugs)